### PR TITLE
Allow record based naming strategies

### DIFF
--- a/avro-serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/avro/AWSKafkaAvroSerializer.java
+++ b/avro-serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/avro/AWSKafkaAvroSerializer.java
@@ -116,9 +116,9 @@ public class AWSKafkaAvroSerializer implements Serializer<Object> {
      * @param topic Name of the topic
      * @return schemaName.
      */
-    private String getSchemaName(String topic) {
+    private String getSchemaName(String topic, Object data) {
         if (schemaName == null) {
-            return schemaNamingStrategy.getSchemaName(topic);
+            return schemaNamingStrategy.getSchemaName(topic, data);
         }
 
         return schemaName;
@@ -129,7 +129,7 @@ public class AWSKafkaAvroSerializer implements Serializer<Object> {
         return AWSSerializerInput.builder()
                 .schemaDefinition(AVROUtils.getInstance()
                                           .getSchemaDefinition(data))
-                .schemaName(getSchemaName(topic))
+                .schemaName(getSchemaName(topic, data))
                 .transportName(topic)
                 .build();
     }

--- a/avro-serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/serializers/avro/AWSKafkaAvroSerializerTest.java
+++ b/avro-serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/serializers/avro/AWSKafkaAvroSerializerTest.java
@@ -31,8 +31,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.services.glue.model.EntityNotFoundException;
 import software.amazon.awssdk.services.glue.model.DataFormat;
+import software.amazon.awssdk.services.glue.model.EntityNotFoundException;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -199,6 +199,12 @@ public class AWSKafkaAvroSerializerTest extends AWSSchemaRegistryValidationUtil 
 
         String schemaDefinition = AVROUtils.getInstance().getSchemaDefinition(genericRecordWithAllTypes);
         AWSKafkaAvroSerializer awsKafkaAvroSerializer = initialize(configs, schemaDefinition, mockClient, USER_SCHEMA_VERSION_ID);
+
+        String schemaName =
+                new CustomerProvidedSchemaNamingStrategy().getSchemaName("User-Topic", genericRecordWithAllTypes);
+
+        when(mockClient.getORRegisterSchemaVersionId(eq(schemaDefinition), eq(schemaName),
+                                                     eq(DataFormat.AVRO.name()), anyMap())).thenReturn(USER_SCHEMA_VERSION_ID);
 
         byte[] serialize = awsKafkaAvroSerializer.serialize("User-Topic", genericRecordWithAllTypes);
         testForSerializedData(serialize, USER_SCHEMA_VERSION_ID, compressionType);

--- a/avro-serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/serializers/avro/CustomerProvidedSchemaNamingStrategy.java
+++ b/avro-serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/serializers/avro/CustomerProvidedSchemaNamingStrategy.java
@@ -16,12 +16,20 @@
 package com.amazonaws.services.schemaregistry.serializers.avro;
 
 import com.amazonaws.services.schemaregistry.common.AWSSchemaNamingStrategy;
+import com.amazonaws.services.schemaregistry.utils.AVROUtils;
+import org.apache.avro.Schema;
 
 public class CustomerProvidedSchemaNamingStrategy implements AWSSchemaNamingStrategy {
-
     @Override
     public String getSchemaName(String p0) {
         return p0;
     }
 
+    @Override
+    public String getSchemaName(String transportName,
+                                Object data) {
+        Schema schema = AVROUtils.getInstance()
+                .getSchema(data);
+        return String.format("%s-%s", transportName, schema.getName());
+    }
 }

--- a/common/src/main/java/com/amazonaws/services/schemaregistry/common/AWSSchemaNamingStrategy.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/common/AWSSchemaNamingStrategy.java
@@ -20,6 +20,9 @@ package com.amazonaws.services.schemaregistry.common;
  * An implementation of this interface can be provided and passed via property.
  */
 public interface AWSSchemaNamingStrategy {
+    default String getSchemaName(String transportName, Object data) {
+        return getSchemaName(transportName);
+    }
     /**
      * Returns the schemaName.
      *

--- a/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
@@ -163,7 +163,7 @@ public class GlueSchemaRegistryConfiguration {
                 throw new AWSSchemaRegistryException(message, e);
             }
         } else {
-            log.debug("Cache Size is not found, using default {}", cacheSize);
+            log.info("Cache Size is not found, using default {}", cacheSize);
         }
     }
 
@@ -177,7 +177,7 @@ public class GlueSchemaRegistryConfiguration {
                 throw new AWSSchemaRegistryException(message, e);
             }
         } else {
-            log.debug("Cache Time to live is not found, using default {}", timeToLiveMillis);
+            log.info("Cache Time to live is not found, using default {}", timeToLiveMillis);
         }
     }
 
@@ -192,7 +192,7 @@ public class GlueSchemaRegistryConfiguration {
         if (isPresent(configs, AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING)) {
             this.schemaAutoRegistrationEnabled = Boolean.parseBoolean(configs.get(AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING).toString());
         } else {
-            log.debug("schemaAutoRegistrationEnabled is not defined in the properties. Using the default value {}",
+            log.info("schemaAutoRegistrationEnabled is not defined in the properties. Using the default value {}",
                     schemaAutoRegistrationEnabled);
         }
     }
@@ -207,7 +207,7 @@ public class GlueSchemaRegistryConfiguration {
                 throw new AWSSchemaRegistryException(AWSSchemaRegistryConstants.TAGS_CONFIG_NOT_HASHMAP_MSG);
             }
         } else {
-            log.debug("Tags value is not defined in the properties. No tags are assigned");
+            log.info("Tags value is not defined in the properties. No tags are assigned");
         }
     }
 

--- a/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
@@ -163,7 +163,7 @@ public class GlueSchemaRegistryConfiguration {
                 throw new AWSSchemaRegistryException(message, e);
             }
         } else {
-            log.info("Cache Size is not found, using default {}", cacheSize);
+            log.debug("Cache Size is not found, using default {}", cacheSize);
         }
     }
 
@@ -177,7 +177,7 @@ public class GlueSchemaRegistryConfiguration {
                 throw new AWSSchemaRegistryException(message, e);
             }
         } else {
-            log.info("Cache Time to live is not found, using default {}", timeToLiveMillis);
+            log.debug("Cache Time to live is not found, using default {}", timeToLiveMillis);
         }
     }
 
@@ -192,7 +192,7 @@ public class GlueSchemaRegistryConfiguration {
         if (isPresent(configs, AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING)) {
             this.schemaAutoRegistrationEnabled = Boolean.parseBoolean(configs.get(AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING).toString());
         } else {
-            log.info("schemaAutoRegistrationEnabled is not defined in the properties. Using the default value {}",
+            log.debug("schemaAutoRegistrationEnabled is not defined in the properties. Using the default value {}",
                     schemaAutoRegistrationEnabled);
         }
     }
@@ -207,7 +207,7 @@ public class GlueSchemaRegistryConfiguration {
                 throw new AWSSchemaRegistryException(AWSSchemaRegistryConstants.TAGS_CONFIG_NOT_HASHMAP_MSG);
             }
         } else {
-            log.info("Tags value is not defined in the properties. No tags are assigned");
+            log.debug("Tags value is not defined in the properties. No tags are assigned");
         }
     }
 


### PR DESCRIPTION
*Issue #17 *

*Description of changes: Added default method to getSchemaName by topic as well as record. Schema can be inferred from record and hence used to construct Schema name. Modified AWSKafkaAvroSerializer to pass data to schema naming strategy. Updated test to validate.*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
