### PR TITLE
One SecondaryDeserializer instance per AWSKafkaAvroDeserializer

### DIFF
--- a/avro-serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/avro/AWSKafkaAvroDeserializer.java
+++ b/avro-serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/avro/AWSKafkaAvroDeserializer.java
@@ -43,6 +43,8 @@ public class AWSKafkaAvroDeserializer implements Deserializer<Object> {
     @Setter
     private AWSDeserializer awsDeserializer;
 
+    private SecondaryDeserializer secondaryDeserializer = SecondaryDeserializer.newInstance();
+
     /**
      * Constructor used by Kafka consumer.
      */
@@ -123,11 +125,10 @@ public class AWSKafkaAvroDeserializer implements Deserializer<Object> {
      * Configure the secondary de-serializer and validate if it's from Kafka.
      */
     private void configureSecondaryDeser(Map<String, ?> configs, boolean isKey) {
-        if (!SecondaryDeserializer.getInstance().validate(configs)) {
+        if (!secondaryDeserializer.validate(configs)) {
             throw new AWSSchemaRegistryException("The secondary deserializer is not from Kafka");
         }
-
-        SecondaryDeserializer.getInstance().configure(configs, isKey);
+        secondaryDeserializer.configure(configs, isKey);
     }
 
     /**
@@ -136,7 +137,7 @@ public class AWSKafkaAvroDeserializer implements Deserializer<Object> {
     private Object deserializeByHeaderVersionByte(String topic, byte[] data, Byte headerVersionByte) {
         return headerVersionByte.equals(AWSSchemaRegistryConstants.HEADER_VERSION_BYTE)
                 ? this.awsDeserializer.deserialize(prepareInput(data, topic))
-                : SecondaryDeserializer.getInstance().deserialize(topic, data);
+                : secondaryDeserializer.deserialize(topic, data);
     }
 
     private Byte getHeaderVersionByte(byte[] data) {

--- a/avro-serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/avro/SecondaryDeserializer.java
+++ b/avro-serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/avro/SecondaryDeserializer.java
@@ -27,12 +27,11 @@ import java.util.Map;
 public class SecondaryDeserializer {
     private Class<?> clz;
     private Object obj;
-    private static final SecondaryDeserializer INSTANCE = new SecondaryDeserializer();
 
     private SecondaryDeserializer() {}
 
-    public static SecondaryDeserializer getInstance() {
-        return INSTANCE;
+    public static SecondaryDeserializer newInstance() {
+        return new SecondaryDeserializer();
     }
 
     public void configure(Map<String, ?> configs, boolean isKey) {

--- a/avro-serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/avro/AWSKafkaAvroDeserializerTest.java
+++ b/avro-serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/avro/AWSKafkaAvroDeserializerTest.java
@@ -17,7 +17,6 @@ package com.amazonaws.services.schemaregistry.deserializers.avro;
 import static com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants.SECONDARY_DESERIALIZER;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/avro-serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/avro/SecondaryDeserializerTest.java
+++ b/avro-serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/avro/SecondaryDeserializerTest.java
@@ -63,7 +63,7 @@ public class SecondaryDeserializerTest {
      */
     @BeforeEach
     public void setup() {
-        secondaryDeserializer = SecondaryDeserializer.getInstance();
+        secondaryDeserializer = SecondaryDeserializer.newInstance();
 
         this.configs.put(AWSSchemaRegistryConstants.AWS_ENDPOINT, "https://test");
         this.configs.put(AWSSchemaRegistryConstants.AWS_REGION, "us-west-2");


### PR DESCRIPTION
*Issue #25 *

*Description of changes:*

Refactored AWSKafkaAvroDeserializer to have it's own SecondaryDeserilizer instance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
