### PR TITLE
Upgrading to latest Flink avro dependency.

### DIFF
--- a/avro-flink-serde/pom.xml
+++ b/avro-flink-serde/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-avro</artifactId>
-            <version>1.11.1</version>
+            <version>1.12.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This is being updated to upgrade Avro version to 1.10.2
