### PR TITLE
Update schema naming strategy to allow key and value based namings

### DIFF
--- a/avro-serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/serializers/avro/AWSKafkaAvroSerializerTest.java
+++ b/avro-serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/serializers/avro/AWSKafkaAvroSerializerTest.java
@@ -201,7 +201,7 @@ public class AWSKafkaAvroSerializerTest extends AWSSchemaRegistryValidationUtil 
         AWSKafkaAvroSerializer awsKafkaAvroSerializer = initialize(configs, schemaDefinition, mockClient, USER_SCHEMA_VERSION_ID);
 
         String schemaName =
-                new CustomerProvidedSchemaNamingStrategy().getSchemaName("User-Topic", genericRecordWithAllTypes);
+                new CustomerProvidedSchemaNamingStrategy().getSchemaName("User-Topic", genericRecordWithAllTypes, true);
 
         when(mockClient.getORRegisterSchemaVersionId(eq(schemaDefinition), eq(schemaName),
                                                      eq(DataFormat.AVRO.name()), anyMap())).thenReturn(USER_SCHEMA_VERSION_ID);
@@ -350,10 +350,11 @@ public class AWSKafkaAvroSerializerTest extends AWSSchemaRegistryValidationUtil 
     @Test
     public void testPrepareInput_nullDefinitionData_throwsException() throws NoSuchMethodException {
         AWSKafkaAvroSerializer awsKafkaAvroSerializer = new AWSKafkaAvroSerializer();
-        Method method = AWSKafkaAvroSerializer.class.getDeclaredMethod("prepareInput", Object.class, String.class);
+        Method method = AWSKafkaAvroSerializer.class.getDeclaredMethod("prepareInput", Object.class, String.class,
+                                                                       Boolean.class);
         method.setAccessible(true);
         try {
-            method.invoke(awsKafkaAvroSerializer,  null, "User-Topic");
+            method.invoke(awsKafkaAvroSerializer,  null, "User-Topic", true);
         } catch(Exception e) {
             assertEquals(IllegalArgumentException.class, e.getCause().getClass());
         }

--- a/avro-serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/serializers/avro/CustomerProvidedSchemaNamingStrategy.java
+++ b/avro-serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/serializers/avro/CustomerProvidedSchemaNamingStrategy.java
@@ -32,4 +32,13 @@ public class CustomerProvidedSchemaNamingStrategy implements AWSSchemaNamingStra
                 .getSchema(data);
         return String.format("%s-%s", transportName, schema.getName());
     }
+
+    @Override
+    public String getSchemaName(String transportName,
+                                Object data,
+                                boolean isKey) {
+        Schema schema = AVROUtils.getInstance()
+                .getSchema(data);
+        return String.format("%s-%s-%s", transportName, schema.getName(), isKey ? "key" : "value");
+    }
 }

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -213,6 +213,7 @@
                         <!-- Ignore exception classes -->
                         <exclude>**/AWSIncompatibleDataException*</exclude>
                         <exclude>**/AWSSchemaRegistryException*</exclude>
+                        <exclude>**/AWSSchemaNamingStrategy*</exclude>
                     </excludes>
                 </configuration>
                 <executions>

--- a/common/src/main/java/com/amazonaws/services/schemaregistry/common/AWSSchemaNamingStrategy.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/common/AWSSchemaNamingStrategy.java
@@ -20,9 +20,17 @@ package com.amazonaws.services.schemaregistry.common;
  * An implementation of this interface can be provided and passed via property.
  */
 public interface AWSSchemaNamingStrategy {
-    default String getSchemaName(String transportName, Object data) {
+    default String getSchemaName(String transportName,
+                                 Object data) {
         return getSchemaName(transportName);
     }
+
+    default String getSchemaName(String transportName,
+                                 Object data,
+                                 boolean isKey) {
+        return isKey ? getSchemaName(transportName) : getSchemaName(transportName, data);
+    }
+
     /**
      * Returns the schemaName.
      *


### PR DESCRIPTION
*Issue #, https://github.com/awslabs/aws-glue-schema-registry/issues/33*

*Description of changes: Extend customization of schema naming strategy by key and value*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
