### PR TITLE
Fixes bug that leaves the ByteBuffer at non-starting position.

### DIFF
--- a/avro-flink-serde/pom.xml
+++ b/avro-flink-serde/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-avro</artifactId>
-            <version>1.11.1</version>
+            <version>1.12.2</version>
         </dependency>
 
         <dependency>

--- a/avro-serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/AWSDeserializer.java
+++ b/avro-serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/AWSDeserializer.java
@@ -20,7 +20,6 @@ import com.amazonaws.services.schemaregistry.common.AWSDeserializerInput;
 import com.amazonaws.services.schemaregistry.common.AWSSchemaRegistryClient;
 import com.amazonaws.services.schemaregistry.common.Schema;
 import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
-import com.amazonaws.services.schemaregistry.deserializers.avro.AWSAvroDeserializer;
 import com.amazonaws.services.schemaregistry.exception.AWSIncompatibleDataException;
 import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryException;
 import lombok.Builder;
@@ -35,7 +34,6 @@ import software.amazon.awssdk.services.glue.model.DataFormat;
 import software.amazon.awssdk.services.glue.model.GetSchemaVersionResponse;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Properties;
@@ -125,14 +123,6 @@ public class AWSDeserializer implements Closeable {
         return awsDeserializerSchema.getSchema();
     }
 
-    private DataFormat getDataFormat(UUID schemaVersionId) {
-        DataFormat dataFormat = null;
-        if (schemaVersionId != null && cache.get(schemaVersionId) != null) {
-            dataFormat = DataFormat.valueOf(cache.get(schemaVersionId).getDataFormat());
-        }
-        return dataFormat;
-    }
-
     /**
      * Fetches the schema definition for a the serialized data.
      *
@@ -177,23 +167,6 @@ public class AWSDeserializer implements Closeable {
         }
         AWSDeserializerDataParser awsDeserializerDataParser = AWSDeserializerDataParser.getInstance();
         return awsDeserializerDataParser.isDataCompatible(ByteBuffer.wrap(data), new StringBuilder());
-    }
-
-    /**
-     * Get the byte array of Avro object to be de-serialized
-     *
-     * @param buffer byte buffer to be de-serialized
-     * @return byte array of Avro object to be de-serialized
-     * @throws IOException Exception during decompression
-     */
-    public byte[] getAvroDeserializedData(@NonNull ByteBuffer buffer) throws IOException {
-        AwsDeserializerSchema awsDeserializerSchema = getAwsDeserializerSchema(buffer);
-        Schema schema = awsDeserializerSchema.getSchema();
-        DataFormat dataFormat = DataFormat.valueOf(schema.getDataFormat());
-        AWSAvroDeserializer awsAvroDeserializer =
-                (AWSAvroDeserializer) deserializerFactory.getInstance(dataFormat, this.glueSchemaRegistryConfiguration);
-
-        return awsAvroDeserializer.getDeserializedData(buffer);
     }
 
     /**

--- a/avro-serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/AWSDeserializerTest.java
+++ b/avro-serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/AWSDeserializerTest.java
@@ -444,41 +444,6 @@ public class AWSDeserializerTest {
     }
 
     /**
-     * Tests getDataFormat method for null result by passing null schema version ID
-     * @throws NoSuchMethodException
-     * @throws InvocationTargetException
-     * @throws IllegalAccessException
-     */
-    @Test
-    public void testGetDataFormat_nullSchemaVersionId_returnsNull() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        AWSDeserializer awsDeserializer = createAwsDeserializer();
-        Method method = AWSDeserializer.class.getDeclaredMethod("getDataFormat", UUID.class);
-        method.setAccessible(true);
-
-        assertNull(method.invoke(awsDeserializer, (UUID) null));
-    }
-
-    /***
-     * Tests getDataFormat for AVRO type by passing AVRO schema version ID
-     * @throws NoSuchMethodException
-     * @throws InvocationTargetException
-     * @throws IllegalAccessException
-     */
-    @Test
-    public void testGetDataFormat_validSchemaVersionId_returnsDataFormat() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        AWSDeserializer awsDeserializer = createAwsDeserializer(mockDeserializerFactory);
-        AWSSchemaRegistryDeserializerCache deserializerCache = invalidateAndGetCache();
-        deserializerCache.put(USER_SCHEMA_VERSION_ID, new Schema(userSchemaDefinition, DataFormat.AVRO.name(),
-                USER_SCHEMA_NAME));
-
-        awsDeserializer.setCache(deserializerCache);
-        Method method = AWSDeserializer.class.getDeclaredMethod("getDataFormat", UUID.class);
-        method.setAccessible(true);
-
-        assertEquals(DataFormat.AVRO, method.invoke(awsDeserializer, USER_SCHEMA_VERSION_ID));
-    }
-
-    /**
      * Tests invoking close method.
      */
     @Test

--- a/avro-serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/avro/AWSAvroDeserializerTest.java
+++ b/avro-serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/avro/AWSAvroDeserializerTest.java
@@ -624,11 +624,6 @@ public class AWSAvroDeserializerTest {
         when(awsAvroDeserializerMock.deserialize(Mockito.any(UUID.class), Mockito.any(ByteBuffer.class),
                 Mockito.anyString())).thenCallRealMethod();
 
-        try {
-            when(awsAvroDeserializerMock.getDeserializedData(Mockito.any(ByteBuffer.class))).thenCallRealMethod();
-        } catch (Exception e) {
-            fail("Test failed with exception", e);
-        }
 
         GlueSchemaRegistryConfiguration config = mock(GlueSchemaRegistryConfiguration.class);
         awsAvroDeserializerMock.setSchemaRegistrySerDeConfigs(config);
@@ -658,12 +653,6 @@ public class AWSAvroDeserializerTest {
         AWSAvroDeserializer awsAvroDeserializerMock = mock(AWSAvroDeserializer.class);
         when(awsAvroDeserializerMock.deserialize(Mockito.any(UUID.class), Mockito.any(ByteBuffer.class),
                 Mockito.anyString())).thenCallRealMethod();
-
-        try {
-            when(awsAvroDeserializerMock.getDeserializedData(Mockito.any(ByteBuffer.class))).thenCallRealMethod();
-        } catch (Exception e) {
-            fail("Test failed with exception", e);
-        }
 
         GlueSchemaRegistryConfiguration config = mock(GlueSchemaRegistryConfiguration.class);
         when(config.getCompressionType()).thenReturn(AWSSchemaRegistryConstants.COMPRESSION.NONE);


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-glue-schema-registry/issues/44

*Description of changes:*

Fixing the bug that leaves the buffer at a non-starting position. In case of `canDeserialize` method, clients have to rewind the buffer by themselves for non-Schema Registry messages.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
