### PR TITLE
Pull everit from maven central instead of jitpack

### DIFF
--- a/jsonschema-kafkaconnect-converter/pom.xml
+++ b/jsonschema-kafkaconnect-converter/pom.xml
@@ -74,8 +74,8 @@
             <artifactId>connect-json</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.everit-org.json-schema</groupId>
-            <artifactId>org.everit.json.schema</artifactId>
+            <groupId>com.github.erosb</groupId>
+            <artifactId>everit-json-schema</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,13 +62,6 @@
         </repository>
     </distributionManagement>
 
-    <repositories>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-    </repositories>
-
     <modules>
         <module>build-tools</module>
         <module>common</module>
@@ -233,8 +226,8 @@
                 <version>${mbknor.jsonschema.converter.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.everit-org.json-schema</groupId>
-                <artifactId>org.everit.json.schema</artifactId>
+                <groupId>com.github.erosb</groupId>
+                <artifactId>everit-json-schema</artifactId>
                 <version>${everit.json.schema.version}</version>
             </dependency>
             <dependency>

--- a/serializer-deserializer/pom.xml
+++ b/serializer-deserializer/pom.xml
@@ -78,8 +78,8 @@
             <artifactId>mbknor-jackson-jsonschema_2.12</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.everit-org.json-schema</groupId>
-            <artifactId>org.everit.json.schema</artifactId>
+            <groupId>com.github.erosb</groupId>
+            <artifactId>everit-json-schema</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-glue-schema-registry/issues/53

*Description of changes:* Pull everit from maven central instead of jitpack.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
