### PR TITLE
Refactor GlueSchemaRegistryDataFormatDeserializer to accept Schema object

### DIFF
--- a/common/src/main/java/com/amazonaws/services/schemaregistry/common/GlueSchemaRegistryDataFormatDeserializer.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/common/GlueSchemaRegistryDataFormatDeserializer.java
@@ -30,5 +30,5 @@ public interface GlueSchemaRegistryDataFormatDeserializer {
      * @param schema   schema for the data
      * @return de-serialized object
      */
-    Object deserialize(@NonNull ByteBuffer data, @NonNull String schema);
+    Object deserialize(@NonNull ByteBuffer data, @NonNull Schema schema);
 }

--- a/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kinesis/GlueSchemaRegistryKinesisIntegrationTest.java
+++ b/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kinesis/GlueSchemaRegistryKinesisIntegrationTest.java
@@ -411,7 +411,7 @@ public class GlueSchemaRegistryKinesisIntegrationTest {
             Schema gsrSchema = glueSchemaRegistryDeserializer.getSchema(consumedBytes);
             LOGGER.info("Consumed Schema from GSR : {}", gsrSchema.getSchemaDefinition());
             Object decodedRecord = gsrDataFormatDeserializer.deserialize(ByteBuffer.wrap(consumedBytes),
-                                                                         gsrSchema.getSchemaDefinition());
+                                                                         gsrSchema);
             consumerRecords.add(decodedRecord);
         }
 

--- a/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kinesis/GlueSchemaRegistryRecordProcessor.java
+++ b/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kinesis/GlueSchemaRegistryRecordProcessor.java
@@ -73,7 +73,7 @@ public class GlueSchemaRegistryRecordProcessor implements ShardRecordProcessor {
                 LOGGER.info("Consumed Schema from GSR : {}", gsrSchema.getSchemaDefinition());
                 Object decodedRecord =
                         glueSchemaRegistryDeserializerFactory.getInstance(DataFormat.valueOf(gsrSchema.getDataFormat()), gsrConfig)
-                                .deserialize(ByteBuffer.wrap(bytes), gsrSchema.getSchemaDefinition());
+                                .deserialize(ByteBuffer.wrap(bytes), gsrSchema);
 
                 this.recordProcessor.consumedRecords.add(decodedRecord);
 

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/GlueSchemaRegistryDeserializationFacade.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/GlueSchemaRegistryDeserializationFacade.java
@@ -150,7 +150,7 @@ public class GlueSchemaRegistryDeserializationFacade implements Closeable {
 
         Object result = deserializerFactory
                 .getInstance(DataFormat.valueOf(schema.getDataFormat()), this.glueSchemaRegistryConfiguration)
-                .deserialize(buffer, schema.getSchemaDefinition());
+                .deserialize(buffer, schema);
 
         return result;
     }

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/avro/AvroDeserializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/avro/AvroDeserializer.java
@@ -77,13 +77,15 @@ public class AvroDeserializer implements GlueSchemaRegistryDataFormatDeserialize
      * from the schema registry.
      *
      * @param buffer   data to be de-serialized
-     * @param schema   Avro schema
+     * @param schemaObject  Avro schema
      * @return de-serialized object
      * @throws AWSSchemaRegistryException Exception during de-serialization
      */
     @Override
-    public Object deserialize(@NonNull ByteBuffer buffer, @NonNull String schema) {
+    public Object deserialize(@NonNull ByteBuffer buffer,
+        @NonNull com.amazonaws.services.schemaregistry.common.Schema schemaObject) {
         try {
+            String schema = schemaObject.getSchemaDefinition();
             byte[] data = DESERIALIZER_DATA_PARSER.getPlainData(buffer);
 
             log.debug("Length of actual message: {}", data.length);

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializer.java
@@ -19,6 +19,7 @@ import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryCo
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializerDataParser;
 import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryException;
 import com.amazonaws.services.schemaregistry.serializers.json.JsonDataWithSchema;
+import com.amazonaws.services.schemaregistry.common.Schema;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -75,14 +76,15 @@ public class JsonDeserializer implements GlueSchemaRegistryDataFormatDeserialize
      * from the schema registry.
      *
      * @param buffer data to be de-serialized
-     * @param schema JSONSchema
+     * @param schemaObject JSONSchema
      * @return de-serialized object
      * @throws AWSSchemaRegistryException Exception during de-serialization
      */
     @Override
     public Object deserialize(@NonNull ByteBuffer buffer,
-                              @NonNull String schema) {
+                              @NonNull Schema schemaObject) {
         try {
+            String schema = schemaObject.getSchemaDefinition();
             byte[] data = DESERIALIZER_DATA_PARSER.getPlainData(buffer);
 
             log.debug("Length of actual message: {}", data.length);

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/protobuf/ProtobufDeserializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/protobuf/ProtobufDeserializer.java
@@ -15,6 +15,7 @@
 package com.amazonaws.services.schemaregistry.deserializers.protobuf;
 
 import com.amazonaws.services.schemaregistry.common.GlueSchemaRegistryDataFormatDeserializer;
+import com.amazonaws.services.schemaregistry.common.Schema;
 import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializerDataParser;
 import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryException;
@@ -44,14 +45,16 @@ public class ProtobufDeserializer implements GlueSchemaRegistryDataFormatDeseria
     }
 
     @Override
-    public Object deserialize(@NonNull ByteBuffer buffer, @NonNull String schema) {
+    public Object deserialize(@NonNull ByteBuffer buffer, @NonNull Schema schema) {
         try {
-            ProtoFileElement fileElement = ProtoParser.Companion.parse(FileDescriptorUtils.DEFAULT_LOCATION, schema);
+            String schemaString = schema.getSchemaDefinition();
+            String schemaName = schema.getSchemaName();
+            ProtoFileElement fileElement = ProtoParser.Companion.parse(FileDescriptorUtils.DEFAULT_LOCATION, schemaString);
             Descriptors.FileDescriptor fileDescriptor = FileDescriptorUtils.protoFileToFileDescriptor(fileElement);
 
             byte[] data = DESERIALIZER_DATA_PARSER.getPlainData(buffer);
 
-            return protoDecoder.decode(data, fileDescriptor, protobufMessageType);
+            return protoDecoder.decode(data, fileDescriptor, protobufMessageType, schemaName);
         } catch (Exception e) {
             throw new AWSSchemaRegistryException("Exception occurred while de-serializing Protobuf message", e);
         }

--- a/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/GlueSchemaRegistryDeserializationFacadeTest.java
+++ b/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/GlueSchemaRegistryDeserializationFacadeTest.java
@@ -19,7 +19,6 @@ import com.amazonaws.services.schemaregistry.common.AWSDeserializerInput;
 import com.amazonaws.services.schemaregistry.common.AWSSchemaRegistryClient;
 import com.amazonaws.services.schemaregistry.common.AWSSerializerInput;
 import com.amazonaws.services.schemaregistry.common.GlueSchemaRegistryDataFormatDeserializer;
-import com.amazonaws.services.schemaregistry.common.Schema;
 import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
 import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryException;
 import com.amazonaws.services.schemaregistry.exception.GlueSchemaRegistryIncompatibleDataException;
@@ -35,7 +34,6 @@ import com.amazonaws.services.schemaregistry.utils.RecordGenerator;
 import com.amazonaws.services.schemaregistry.utils.SchemaLoader;
 import com.amazonaws.services.schemaregistry.utils.SerializedByteArrayGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
@@ -61,8 +59,6 @@ import software.amazon.awssdk.services.glue.model.GetSchemaVersionResponse;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -102,7 +98,7 @@ public class GlueSchemaRegistryDeserializationFacadeTest {
     private static final String EMPLOYEE_SCHEMA_NAME = "Employee";
     private static final UUID EMPLOYEE_SCHEMA_VERSION_ID = UUID.randomUUID();
     private static final String EMPLOYEE_SCHEMA_ARN =
-            "arn:aws:glue:ca-central-1:111111111111:schema/registry_name" + "/user_schema";
+            "arn:aws:glue:ca-central-1:111111111111:schema/registry_name" + "/employee_schema";
 
     private static final AVROUtils AVRO_UTILS = AVROUtils.getInstance();
     private static final GenericRecord genericAvroRecord = RecordGenerator.createGenericAvroRecord();
@@ -288,10 +284,12 @@ public class GlueSchemaRegistryDeserializationFacadeTest {
                 Mockito.eq(EMPLOYEE_SCHEMA_VERSION_ID.toString()))).thenReturn(employeeSchemaVersionResponse);
 
         when(mockDataFormatDeserializer.deserialize(Mockito.any(ByteBuffer.class),
-                                                    Mockito.eq(employeeAvroSchema.toString()))).thenReturn(
+                                                    Mockito.eq(new com.amazonaws.services.schemaregistry.common.Schema(
+                                                            employeeAvroSchema.toString(), DataFormat.AVRO.name(), "employee_schema")))).thenReturn(
                 genericEmployeeAvroRecord);
         when(mockDataFormatDeserializer.deserialize(Mockito.any(ByteBuffer.class),
-                                                    Mockito.eq(userAvroSchema.toString()))).thenReturn(
+                                                    Mockito.eq(new com.amazonaws.services.schemaregistry.common.Schema(
+                                                            userAvroSchema.toString(), DataFormat.AVRO.name(), "user_schema")))).thenReturn(
                 genericUserAvroRecord);
 
         when(mockDeserializerFactory.getInstance(Mockito.any(DataFormat.class),
@@ -311,7 +309,7 @@ public class GlueSchemaRegistryDeserializationFacadeTest {
     }
 
     /**
-     * Tests the GlueSchemaRegistryDeserializationFacade instantiation when an no configuration is provided.
+     * Tests the GlueSchemaRegistryemployeeDeserializationFacade instantiation when an no configuration is provided.
      */
     @Test
     public void testBuildDeserializer_withNoArguments_throwsException() {
@@ -671,7 +669,7 @@ public class GlueSchemaRegistryDeserializationFacadeTest {
         Object deserializedEmployeeObject =
                 glueSchemaRegistryDeserializationFacade.deserialize(prepareDeserializerInput(serializedEmployeeData));
 
-        assertEquals(deserializedUserObject, deserializedUserObject);
+        assertEquals(genericUserAvroRecord, deserializedUserObject);
         assertEquals(genericEmployeeAvroRecord, deserializedEmployeeObject);
     }
 

--- a/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializerTest.java
+++ b/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializerTest.java
@@ -18,6 +18,9 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import com.amazonaws.services.schemaregistry.common.Schema;
+import software.amazon.awssdk.services.glue.model.DataFormat;
+
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -37,8 +40,9 @@ public class JsonDeserializerTest {
         String jsonData = "{\"latitude\":48.858093,\"longitude\":2.294694}";
         byte[] testBytes = jsonData.getBytes(StandardCharsets.UTF_8);
 
-        assertThrows(IllegalArgumentException.class, () -> jsonDeserializer.deserialize(null,
-                                                                                        testSchemaDefinition));
+        Schema testSchema = new Schema(testSchemaDefinition, DataFormat.JSON.name(), "testJson");
+
+        assertThrows(IllegalArgumentException.class, () -> jsonDeserializer.deserialize(null, testSchema));
         assertThrows(IllegalArgumentException.class, () -> jsonDeserializer.deserialize(ByteBuffer.wrap(testBytes),
                                                                                         null));
     }


### PR DESCRIPTION
**Background**

In order to de-serialize proto messages into POJOs, we need to know the file name of the original proto file registered. We will be using the schemaName as the proto file name. This change refactors the de-serializer to accept Schema object instead of plain schema definition. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
