### PR TITLE
Add support to deserialize to Protobuf POJOs.

### DIFF
--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/GlueSchemaRegistryDeserializerFactory.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/GlueSchemaRegistryDeserializerFactory.java
@@ -18,6 +18,7 @@ import com.amazonaws.services.schemaregistry.common.GlueSchemaRegistryDataFormat
 import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
 import com.amazonaws.services.schemaregistry.deserializers.avro.AvroDeserializer;
 import com.amazonaws.services.schemaregistry.deserializers.json.JsonDeserializer;
+import com.amazonaws.services.schemaregistry.deserializers.protobuf.ProtobufDeserializer;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.glue.model.DataFormat;
@@ -59,6 +60,12 @@ public class GlueSchemaRegistryDeserializerFactory {
                         .configs(configs)
                         .build());
                 log.debug("Returning JSON de-serializer instance from GlueSchemaRegistryDeserializerFactory");
+                return this.deserializerMap.get(dataFormat);
+            case PROTOBUF:
+                this.deserializerMap.computeIfAbsent(dataFormat, key -> ProtobufDeserializer.builder()
+                        .configs(configs)
+                        .build());
+                log.debug("Returning Protobuf de-serializer instance from GlueSchemaRegistryDeserializerFactory");
                 return this.deserializerMap.get(dataFormat);
             default:
                 String message = String.format("Data Format is not supported %s", dataFormat);

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/protobuf/ProtobufSchemaParser.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/protobuf/ProtobufSchemaParser.java
@@ -1,0 +1,17 @@
+package com.amazonaws.services.schemaregistry.deserializers.protobuf;
+
+import com.google.protobuf.Descriptors;
+import com.squareup.wire.schema.internal.parser.ProtoFileElement;
+import com.squareup.wire.schema.internal.parser.ProtoParser;
+import io.apicurio.registry.utils.protobuf.schema.FileDescriptorUtils;
+
+/**
+ * Utility class to parse the Protobuf schemas using square and apicurio library.
+ */
+public class ProtobufSchemaParser {
+    public static Descriptors.FileDescriptor parse(final String schemaDefinition, final String protoFileName)
+        throws Descriptors.DescriptorValidationException {
+        ProtoFileElement fileElement = ProtoParser.Companion.parse(FileDescriptorUtils.DEFAULT_LOCATION, schemaDefinition);
+        return FileDescriptorUtils.protoFileToFileDescriptor(fileElement, protoFileName);
+    }
+}

--- a/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/protobuf/ProtobufDeserializerTest.java
+++ b/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/protobuf/ProtobufDeserializerTest.java
@@ -1,14 +1,14 @@
 package com.amazonaws.services.schemaregistry.deserializers.protobuf;
 
+import com.amazonaws.services.schemaregistry.common.Schema;
 import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
 import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryException;
 import com.amazonaws.services.schemaregistry.serializers.SerializationDataEncoder;
-import com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator;
 import com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufSerializer;
-import com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufTestCase;
-import com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufTestCaseReader;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
+import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -17,64 +17,79 @@ import software.amazon.awssdk.services.glue.model.DataFormat;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.BASIC_REFERENCING_DYNAMIC_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.BASIC_SYNTAX2_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.BASIC_SYNTAX3_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.DOLLAR_SYNTAX_3_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.DOUBLE_PROTO_WITH_TRAILING_HASH_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.NESTING_MESSAGE_PROTO2;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.NESTING_MESSAGE_PROTO3;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.SPECIAL_CHARS_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.UNICODE_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.createDynamicProtobufRecord;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufTestCaseReader.getTestCaseByName;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ProtobufDeserializerTest {
-    private static GlueSchemaRegistryConfiguration dynamicMessageConfigs = new GlueSchemaRegistryConfiguration(new HashMap<String, String>() {{
-            put(AWSSchemaRegistryConstants.AWS_REGION, "us-west-2");
-            put(AWSSchemaRegistryConstants.PROTOBUF_MESSAGE_TYPE, "DYNAMIC_MESSAGE");
-            }});
-    private ProtobufDeserializer protobufDynamicMessageDeserializer =
+    public static final String SCHEMA_NAME = "Basic";
+    private static final ByteBuffer ANY_BUFFER = ByteBuffer.wrap(new byte[] { 1, 2, 3 });
+    private static final Schema ANY_SCHEMA =
+        new com.amazonaws.services.schemaregistry.common.Schema("foo", DataFormat.PROTOBUF.name(), SCHEMA_NAME);
+    private static GlueSchemaRegistryConfiguration dynamicMessageConfigs =
+        new GlueSchemaRegistryConfiguration(ImmutableMap.of(
+            AWSSchemaRegistryConstants.AWS_REGION, "us-west-2",
+            AWSSchemaRegistryConstants.PROTOBUF_MESSAGE_TYPE, "DYNAMIC_MESSAGE"
+        ));
+    private final ProtobufDeserializer protobufDynamicMessageDeserializer =
             new ProtobufDeserializer(dynamicMessageConfigs);
 
-    private static GlueSchemaRegistryConfiguration unknownMessageConfigs = new GlueSchemaRegistryConfiguration(new HashMap<String, String>() {{
-            put(AWSSchemaRegistryConstants.AWS_REGION, "us-west-2");
-            put(AWSSchemaRegistryConstants.PROTOBUF_MESSAGE_TYPE, "UNKNOWN");
-            }});
-    private ProtobufDeserializer protobufUnknownMessageTypeDeserializer =
-            new ProtobufDeserializer(unknownMessageConfigs);
-
-    private static GlueSchemaRegistryConfiguration pojoMessageConfigs = new GlueSchemaRegistryConfiguration(new HashMap<String, String>() {
-        {
-            put(AWSSchemaRegistryConstants.AWS_REGION, "us-west-2");
-            put(AWSSchemaRegistryConstants.PROTOBUF_MESSAGE_TYPE, "POJO");
-        }});
-    private ProtobufDeserializer protobufPojoMessageTypeDeserializer =
+    private static GlueSchemaRegistryConfiguration pojoMessageConfigs =
+        new GlueSchemaRegistryConfiguration(ImmutableMap.of(
+            AWSSchemaRegistryConstants.AWS_REGION, "us-west-2",
+            AWSSchemaRegistryConstants.PROTOBUF_MESSAGE_TYPE, "POJO"
+        ));
+    private final ProtobufDeserializer protobufPojoMessageTypeDeserializer =
             new ProtobufDeserializer(pojoMessageConfigs);
 
     private static ProtobufSerializer protobufSerializer = new ProtobufSerializer(dynamicMessageConfigs);
-    private static final SerializationDataEncoder encoder = new SerializationDataEncoder(dynamicMessageConfigs);
+    private static final SerializationDataEncoder SERIALIZATION_DATA_ENCODER = new SerializationDataEncoder(dynamicMessageConfigs);
     private static final UUID SCHEMA_VERSION_ID_FOR_TESTING = UUID.fromString("b7b4a7f0-9c96-4e4a-a687-fb5de9ef0c63");
 
-
-    private static Stream<Arguments> testDynamicMessageProviderWithMessageIndex0() {
-        ProtobufTestCase testCase =
-                ProtobufTestCaseReader.getTestCaseByName("Basic.proto");
-        DynamicMessage addressDynamicMessage = ProtobufGenerator.createDynamicProtobufRecord();
-        ByteBuffer buffer = ByteBuffer.wrap(encoder.write(protobufSerializer.serialize(addressDynamicMessage),
-                SCHEMA_VERSION_ID_FOR_TESTING));
-        String schema = testCase.getRawSchema();
+    private static Stream<Arguments> testDeserializationMessageProvider() {
         return Stream.of(
-                Arguments.of(addressDynamicMessage, buffer, schema)
-        );
-    }
-
-    private static Stream<Arguments> testDynamicMessageProviderWithNonZeroMessageIndex() {
-        ProtobufTestCase testCase =
-                ProtobufTestCaseReader.getTestCaseByName("ComplexNestingSyntax3.proto");
-        DynamicMessage message = ProtobufGenerator.createDynamicNRecord();
-        ByteBuffer buffer = ByteBuffer.wrap(encoder.write(protobufSerializer.serialize(message),
-                SCHEMA_VERSION_ID_FOR_TESTING));
-        String schema = testCase.getRawSchema();
-        return Stream.of(
-                Arguments.of(message, buffer, schema)
+            Arguments.of(
+                NESTING_MESSAGE_PROTO2, getTestCaseByName("ComplexNestingSyntax2.proto").getRawSchema(), "ComplexNestingSyntax2.proto"
+            ),
+            Arguments.of(
+                NESTING_MESSAGE_PROTO3, getTestCaseByName("ComplexNestingSyntax3.proto").getRawSchema(), "ComplexNestingSyntax3.proto"
+            ),
+            Arguments.of(
+                BASIC_REFERENCING_DYNAMIC_MESSAGE, getTestCaseByName("Basic.proto").getRawSchema(), "Basic.proto"
+            ),
+            Arguments.of(
+                BASIC_SYNTAX3_MESSAGE, getTestCaseByName("basicsyntax3.proto").getRawSchema(), "basicsyntax3"
+            ),
+            Arguments.of(
+                BASIC_SYNTAX2_MESSAGE, getTestCaseByName("basicSyntax2.proto").getRawSchema(), "basicSyntax2"
+            ),
+            Arguments.of(
+                DOUBLE_PROTO_WITH_TRAILING_HASH_MESSAGE, getTestCaseByName(".protodevelasl.proto.proto.protodevel#$---$#$#.bar.3#.proto").getRawSchema(), ".protodevelasl.proto.proto.protodevel#$---$#$#.bar.3#"
+            ),
+            Arguments.of(
+                UNICODE_MESSAGE, getTestCaseByName("◉◉◉unicode⏩.proto").getRawSchema(), "◉◉◉unicode⏩.proto"
+            ),
+            Arguments.of(
+                SPECIAL_CHARS_MESSAGE, getTestCaseByName("*&()^#!`~;:\"'{[}}<,>>.special?.proto").getRawSchema(), "*&()^#!`~;:\"'{[}}<,>>.special?"
+            ),
+            Arguments.of(
+                DOLLAR_SYNTAX_3_MESSAGE, getTestCaseByName("foo$$$1.proto").getRawSchema(), "foo$$$1.proto"
+            )
         );
     }
 
@@ -88,13 +103,14 @@ public class ProtobufDeserializerTest {
 
     @Test
     public void testDeserialize_NullArgs_ThrowsException() {
-        DynamicMessage dynamicMessage = ProtobufGenerator.createDynamicProtobufRecord();
-        ByteBuffer buffer = ByteBuffer.wrap(encoder.write(protobufSerializer.serialize(dynamicMessage),
+        DynamicMessage dynamicMessage = createDynamicProtobufRecord();
+        ByteBuffer buffer = ByteBuffer.wrap(SERIALIZATION_DATA_ENCODER.write(protobufSerializer.serialize(dynamicMessage),
                 SCHEMA_VERSION_ID_FOR_TESTING));
-        String schema = ProtobufTestCaseReader.getTestCaseByName("Basic.proto").getRawSchema();
+        String schema = getTestCaseByName("Basic.proto").getRawSchema();
 
-        com.amazonaws.services.schemaregistry.common.Schema schemaObject = new com.amazonaws.services.schemaregistry.common.Schema(
-                schema, DataFormat.PROTOBUF.name(), "Basic");
+        com.amazonaws.services.schemaregistry.common.Schema schemaObject =
+            new com.amazonaws.services.schemaregistry.common.Schema(
+                schema, DataFormat.PROTOBUF.name(), SCHEMA_NAME);
 
         Exception ex = assertThrows(IllegalArgumentException.class,
                 () -> protobufDynamicMessageDeserializer.deserialize(null, schemaObject));
@@ -106,74 +122,50 @@ public class ProtobufDeserializerTest {
     }
 
     @ParameterizedTest
-    @MethodSource("testDynamicMessageProviderWithMessageIndex0")
-    public void testDeserialize_DynamicMessage_Succeeds(DynamicMessage dynamicMessage, ByteBuffer buffer, String schema) {
-        com.amazonaws.services.schemaregistry.common.Schema schemaObject = new com.amazonaws.services.schemaregistry.common.Schema(
-                schema, DataFormat.PROTOBUF.name(), "Basic");
+    @MethodSource("testDeserializationMessageProvider")
+    public void testDeserialize_DynamicMessage_Succeeds(Message message, String schemaDef, String schemaName) {
+        byte[] serializedData = protobufSerializer.serialize(message);
+        com.amazonaws.services.schemaregistry.common.Schema schemaObject =
+            new com.amazonaws.services.schemaregistry.common.Schema(
+                schemaDef, DataFormat.PROTOBUF.name(), schemaName);
+        ByteBuffer byteBuffer =
+            ByteBuffer.wrap(SERIALIZATION_DATA_ENCODER.write(serializedData, SCHEMA_VERSION_ID_FOR_TESTING));
 
-        Object deserializedObject = protobufDynamicMessageDeserializer.deserialize(buffer, schemaObject);
+        DynamicMessage deserializedObject =
+            (DynamicMessage) protobufDynamicMessageDeserializer.deserialize(byteBuffer, schemaObject);
 
-        assertArrayEquals(protobufSerializer.serialize(dynamicMessage),
-                protobufSerializer.serialize(deserializedObject));
-        //TODO: could not assert equals do to varied descriptor addresses for the two objects
+        assertArrayEquals(message.toByteArray(), deserializedObject.toByteArray());
     }
 
     @ParameterizedTest
-    @MethodSource("testDynamicMessageProviderWithNonZeroMessageIndex")
-    public void testDeserialize_DynamicMessageN_Succeeds(DynamicMessage dynamicMessage, ByteBuffer buffer, String schema) {
-        com.amazonaws.services.schemaregistry.common.Schema schemaObject = new com.amazonaws.services.schemaregistry.common.Schema(
-                schema, DataFormat.PROTOBUF.name(), "Basic");
-        Object deserializedObject = protobufDynamicMessageDeserializer.deserialize(buffer, schemaObject);
-        assertArrayEquals(protobufSerializer.serialize(dynamicMessage),
-                protobufSerializer.serialize(deserializedObject));
-        //TODO: could not assert equals do to varied descriptor addresses for the two objects
+    @MethodSource("testDeserializationMessageProvider")
+    public void testDeserialize_WhenDeserializedToPOJO_Succeeds(Message message, String schemaDef, String schemaName) {
+        byte[] serializedData = protobufSerializer.serialize(message);
+        com.amazonaws.services.schemaregistry.common.Schema schemaObject =
+            new com.amazonaws.services.schemaregistry.common.Schema(
+                schemaDef, DataFormat.PROTOBUF.name(), schemaName);
+        ByteBuffer byteBuffer =
+            ByteBuffer.wrap(SERIALIZATION_DATA_ENCODER.write(serializedData, SCHEMA_VERSION_ID_FOR_TESTING));
+
+        Message deserializedObject =
+            (Message) protobufPojoMessageTypeDeserializer.deserialize(byteBuffer, schemaObject);
+
+        assertArrayEquals(message.toByteArray(), deserializedObject.toByteArray());
     }
 
-    @ParameterizedTest
-    @MethodSource("testDynamicMessageProviderWithMessageIndex0")
-    public void testDeserialize_DynamicMessage_ThrowsExceptionInvalidSchema(
-            DynamicMessage dynamicMessage, ByteBuffer buffer, String schema) {
-        Exception ex = assertThrows(IllegalArgumentException.class, () -> protobufDynamicMessageDeserializer.deserialize(buffer, null));
+    @Test
+    public void testDeserialize_DynamicMessage_ThrowsExceptionInvalidSchema() {
+        Exception ex = assertThrows(IllegalArgumentException.class,
+            () -> protobufDynamicMessageDeserializer.deserialize(ANY_BUFFER, null));
         assertEquals("schema is marked non-null but is null", ex.getMessage());
     }
 
-    @ParameterizedTest
-    @MethodSource("testDynamicMessageProviderWithMessageIndex0")
-    public void testDeserialize_DynamicMessage_ThrowsExceptionInvalidBytes(
-            DynamicMessage dynamicMessage, ByteBuffer buffer, String schema) {
-        com.amazonaws.services.schemaregistry.common.Schema schemaObject = new com.amazonaws.services.schemaregistry.common.Schema(
-                schema, DataFormat.PROTOBUF.name(), "Basic");
-
+    @Test
+    public void testDeserialize_DynamicMessage_ThrowsExceptionInvalidBytes() {
         String random = "invalid bytes";
         ByteBuffer invalidBytes = ByteBuffer.wrap(random.getBytes(StandardCharsets.UTF_8));
         Exception ex = assertThrows(AWSSchemaRegistryException.class,
-                () -> protobufDynamicMessageDeserializer.deserialize(invalidBytes, schemaObject));
+            () -> protobufDynamicMessageDeserializer.deserialize(invalidBytes, ANY_SCHEMA));
         assertEquals("Exception occurred while de-serializing Protobuf message", ex.getMessage());
     }
-
-    @ParameterizedTest
-    @MethodSource("testDynamicMessageProviderWithMessageIndex0")
-    public void testDeserialize_DynamicMessage_UnknownMessageType_Succeeds(
-            DynamicMessage dynamicMessage, ByteBuffer buffer, String schema) {
-        com.amazonaws.services.schemaregistry.common.Schema schemaObject = new com.amazonaws.services.schemaregistry.common.Schema(
-                schema, DataFormat.PROTOBUF.name(), "Basic");
-
-        Object deserializedObject = protobufUnknownMessageTypeDeserializer.deserialize(buffer, schemaObject);
-
-        assertArrayEquals(protobufSerializer.serialize(dynamicMessage),
-                protobufSerializer.serialize(deserializedObject));
-    }
-
-    @ParameterizedTest
-    @MethodSource("testDynamicMessageProviderWithMessageIndex0")
-    public void testDeserialize_POJO(DynamicMessage dynamicMessage, ByteBuffer buffer, String schema) {
-        com.amazonaws.services.schemaregistry.common.Schema schemaObject = new com.amazonaws.services.schemaregistry.common.Schema(
-                schema, DataFormat.PROTOBUF.name(), "Basic");
-        Object deserializedObject = protobufPojoMessageTypeDeserializer.deserialize(buffer, schemaObject);
-
-        assertArrayEquals(protobufSerializer.serialize(dynamicMessage),
-                protobufSerializer.serialize(deserializedObject));
-    }
-
-
 }

--- a/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/protobuf/ProtobufWireFormatDecoderTest.java
+++ b/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/protobuf/ProtobufWireFormatDecoderTest.java
@@ -1,90 +1,147 @@
 package com.amazonaws.services.schemaregistry.deserializers.protobuf;
 
+import Foo.Contact;
 import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
-import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializerDataParser;
-import com.amazonaws.services.schemaregistry.serializers.SerializationDataEncoder;
-import com.amazonaws.services.schemaregistry.serializers.protobuf.*;
-import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
+import com.amazonaws.services.schemaregistry.serializers.protobuf.MessageIndexFinder;
+import com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator;
+import com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufSerializer;
+import com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufTestCase;
+import com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufTestCaseReader;
+import com.amazonaws.services.schemaregistry.tests.protobuf.syntax2.Basic;
+import com.amazonaws.services.schemaregistry.tests.protobuf.syntax2.ComplexNestingSyntax2;
+import com.amazonaws.services.schemaregistry.tests.protobuf.syntax2.basic.BasicSyntax2;
+import com.amazonaws.services.schemaregistry.tests.protobuf.syntax2.snake_case.SnakeCaseFile;
+import com.amazonaws.services.schemaregistry.tests.protobuf.syntax3.ComplexNestingSyntax3;
+import com.amazonaws.services.schemaregistry.tests.protobuf.syntax3.basic.Basicsyntax3;
+import com.amazonaws.services.schemaregistry.tests.protobuf.syntax3.basic.ConflictingNameOuterClass;
+import com.amazonaws.services.schemaregistry.tests.protobuf.syntax3.basic.Foo1;
+import com.amazonaws.services.schemaregistry.tests.protobuf.syntax3.basic.HyphenAtedProtoFile;
+import com.amazonaws.services.schemaregistry.tests.protobuf.syntax3.basic.NestedConflictingClassNameOuterClass;
+import com.amazonaws.services.schemaregistry.tests.protobuf.syntax2.basic.ProtodevelaslProtoProtoProtodevelBar3_;
+import com.amazonaws.services.schemaregistry.tests.protobuf.syntax3.basic.Special;
+import com.amazonaws.services.schemaregistry.tests.protobuf.syntax3.basic.Unicode;
+import com.amazonaws.services.schemaregistry.tests.protobuf.syntax3.snake_case.AnotherSnakeCaseProtoFile;
 import com.amazonaws.services.schemaregistry.utils.ProtobufMessageType;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
-import org.junit.jupiter.api.Assertions;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.UUID;
+import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.*;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ProtobufWireFormatDecoderTest {
-    private GlueSchemaRegistryConfiguration configs = new GlueSchemaRegistryConfiguration(new HashMap<String, String>() {{
-        put(AWSSchemaRegistryConstants.AWS_REGION, "us-west-2");
-    }});
-    private final UUID SCHEMA_VERSION_ID_FOR_TESTING = UUID.fromString("b7b4a7f0-9c96-4e4a-a687-fb5de9ef0c63");
-    private final GlueSchemaRegistryDeserializerDataParser deserializerDataParser =
-            GlueSchemaRegistryDeserializerDataParser.getInstance();
-    private ProtobufSerializer protobufSerializer = new ProtobufSerializer(configs);
-    private ProtobufWireFormatDecoder decoder = new ProtobufWireFormatDecoder(new MessageIndexFinder());
-    private SerializationDataEncoder encoder = new SerializationDataEncoder(configs);
-    private DynamicMessage dynamicMessage = ProtobufGenerator.createDynamicProtobufRecord();
-    private ProtobufTestCase basicTestCase = ProtobufTestCaseReader.getTestCaseByName("Basic.proto");
-    private Descriptors.FileDescriptor basicFileDescriptor = basicTestCase.getSchema();
-    private ByteBuffer dynamicMessageBuffer =
-            ByteBuffer.wrap(encoder.write(protobufSerializer.serialize(dynamicMessage), SCHEMA_VERSION_ID_FOR_TESTING));
-    byte[] dynamicMessageData = deserializerDataParser.getPlainData(dynamicMessageBuffer);
-
-    @Test
-    public void testDecodeDynamicMessage_ValidInputs_Succeeds() throws IOException {
-        Object decoded = decoder.decode(dynamicMessageData, basicFileDescriptor, ProtobufMessageType.DYNAMIC_MESSAGE);
-        DynamicMessage decodedDynamicMessage = (DynamicMessage) decoded;
-        assertArrayEquals(dynamicMessage.toByteArray(), decodedDynamicMessage.toByteArray());
-
-        //TODO: could not assert equals do to varied descriptor addresses for the two objects
-    }
+    private final GlueSchemaRegistryConfiguration configs = new GlueSchemaRegistryConfiguration("us-west-2");
+    private final ProtobufSerializer protobufSerializer = new ProtobufSerializer(configs);
+    private final ProtobufWireFormatDecoder decoder = new ProtobufWireFormatDecoder(new MessageIndexFinder());
+    private final ProtobufTestCase basicTestCase = ProtobufTestCaseReader.getTestCaseByName("Basic.proto");
+    private final Descriptors.FileDescriptor basicFileDescriptor = basicTestCase.getSchema();
 
     @Test
     public void testDecodeDynamicMessage_NullInputStream_ThrowsException() {
         Exception ex = assertThrows(IllegalArgumentException.class,
-                () -> decoder.decode(null, basicFileDescriptor,
-                        ProtobufMessageType.DYNAMIC_MESSAGE));
+            () -> decoder.decode(null, basicFileDescriptor,
+                ProtobufMessageType.DYNAMIC_MESSAGE));
         assertEquals("data is marked non-null but is null", ex.getMessage());
     }
 
     @Test
     public void testDecodeDynamicMessage_NullDescriptor_ThrowsException() {
         Exception ex = assertThrows(IllegalArgumentException.class,
-                () -> decoder.decode(null, null, ProtobufMessageType.DYNAMIC_MESSAGE));
-        assertEquals("data is marked non-null but is null", ex.getMessage());
+            () -> decoder.decode(new byte[] {}, null, ProtobufMessageType.DYNAMIC_MESSAGE));
+        assertEquals("descriptor is marked non-null but is null", ex.getMessage());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getDynamicMessageDecoderTestCases")
+    public void testDecode_UnknownMessageTypeValidInputs_ToDynamicMessage_Succeeds(DynamicMessage dynamicMessage, ProtobufMessageType protobufMessageType) throws IOException {
+        byte[] serializedBytes = protobufSerializer.serialize(dynamicMessage);
+        DynamicMessage decoded = (DynamicMessage) decoder.decode(serializedBytes, dynamicMessage.getDescriptorForType().getFile(), protobufMessageType);
+        assertArrayEquals(dynamicMessage.toByteArray(), decoded.toByteArray());
     }
 
     @Test
-    public void testDecode_DynamicMessage_WhenValidInputsArePassed_Succeeds() throws IOException {
-        Object decoded = decoder.decode(dynamicMessageData, basicFileDescriptor, ProtobufMessageType.DYNAMIC_MESSAGE);
-        Assertions.assertArrayEquals(dynamicMessageData, protobufSerializer.serialize(decoded));
-        //TODO: could not assert equals do to varied descriptor addresses for the two objects
+    public void testDecode_DynamicMessage_CorruptedMessageIndex_ThrowsException() {
+        byte[] invalidData = "\uD83D\uDE0B".getBytes(StandardCharsets.UTF_8);
+        Exception ex = assertThrows(InvalidProtocolBufferException.class,
+            () -> decoder.decode(invalidData, basicFileDescriptor, ProtobufMessageType.DYNAMIC_MESSAGE));
+        assertEquals("While parsing a protocol message, " +
+            "the input ended unexpectedly in the middle of a field.  This could mean either that the input has " +
+            "been truncated or that an embedded message misreported its own length.", ex.getMessage());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getPOJODecoderTestCases")
+    public void testDecode_WhenMessagesArePassed_DeserializesThemIntoCorrectPOJOs(Message message, Class<?> expectedClass)
+        throws IOException {
+        byte[] data = protobufSerializer.serialize(message);
+        Descriptors.FileDescriptor fileDescriptor = message.getDescriptorForType().getFile();
+
+        Object decodedObject = decoder.decode(data, fileDescriptor, ProtobufMessageType.POJO);
+
+        assertTrue(expectedClass.isInstance(decodedObject));
+        assertEquals(message, decodedObject);
     }
 
     @Test
-    public void testDecode_UnknownMessageTypeValidInputs_ToDynamicMessage_Succeeds() throws IOException {
-        Object decoded = decoder.decode(dynamicMessageData, basicFileDescriptor, ProtobufMessageType.UNKNOWN);
-        Assertions.assertArrayEquals(dynamicMessageData, protobufSerializer.serialize(decoded));
-        //TODO: could not assert equals do to varied descriptor addresses for the two objects
+    public void testDecode_WhenPOJOClassIsNotFound_ThrowsRuntimeException()
+        throws Descriptors.DescriptorValidationException {
+
+        Message nonPOJOExistentMessage = ProtobufGenerator.createRuntimeCompiledRecord();
+        byte[] nonExistentMessageBytes = protobufSerializer.serialize(nonPOJOExistentMessage);
+
+        Exception ex = assertThrows(RuntimeException.class,
+            () -> decoder.decode(nonExistentMessageBytes, nonPOJOExistentMessage.getDescriptorForType().getFile(), ProtobufMessageType.POJO));
+        assertEquals("Error de-serializing data into Message class: foo.NonExistent$NonExistentSchema", ex.getMessage());
+
+        Throwable rootCause = ex.getCause();
+        assertEquals(ClassNotFoundException.class, rootCause.getClass());
+        assertEquals("foo.NonExistent$NonExistentSchema", rootCause.getMessage());
     }
 
-    @Test
-    public void testDecode_DynamicMessage_InvalidMessageIndex_ThrowsException() {
-        String s = "";
-        byte[] invalidData = s.getBytes(StandardCharsets.UTF_8);
-        Exception ex = assertThrows(UncheckedIOException.class,
-                () -> decoder.decode(invalidData, basicFileDescriptor, ProtobufMessageType.DYNAMIC_MESSAGE));
-        assertEquals("com.google.protobuf.InvalidProtocolBufferException: While parsing a protocol message, " +
-                "the input ended unexpectedly in the middle of a field.  This could mean either that the input has " +
-                "been truncated or that an embedded message misreported its own length.", ex.getMessage());
+    private static Stream<Arguments> getPOJODecoderTestCases() {
+        return Stream.of(
+            Arguments.of(BASIC_SYNTAX2_MESSAGE, BasicSyntax2.Phone.class),
+            Arguments.of(BASIC_SYNTAX3_MESSAGE, Basicsyntax3.Phone.class),
+            Arguments.of(BASIC_REFERENCING_MESSAGE, Basic.Customer.class),
+            Arguments.of(BASIC_REFERENCING_DYNAMIC_MESSAGE, Basic.Address.class),
+            Arguments.of(JAVA_OUTER_CLASS_MESSAGE, Contact.Phone.class),
+            Arguments.of(JAVA_OUTER_CLASS_WITH_MULTIPLE_FILES_MESSAGE,
+                com.amazonaws.services.schemaregistry.tests.protobuf.syntax3.multiplefiles.Phone.class),
+            Arguments.of(NESTING_MESSAGE_PROTO3, ComplexNestingSyntax3.A.B.C.X.D.F.M.class),
+            Arguments.of(NESTING_MESSAGE_PROTO2, ComplexNestingSyntax2.O.A.class),
+            Arguments.of(SNAKE_CASE_MESSAGE, SnakeCaseFile.snake_case_message.class),
+            Arguments.of(ANOTHER_SNAKE_CASE_MESSAGE, AnotherSnakeCaseProtoFile.another_SnakeCase_.class),
+            Arguments.of(DOLLAR_SYNTAX_3_MESSAGE, Foo1.Dollar.class),
+            Arguments.of(HYPHEN_ATED_PROTO_FILE_MESSAGE, HyphenAtedProtoFile.hyphenated.class),
+            Arguments.of(DOUBLE_PROTO_WITH_TRAILING_HASH_MESSAGE, ProtodevelaslProtoProtoProtodevelBar3_.bar.class),
+            Arguments.of(SPECIAL_CHARS_MESSAGE, Special.specialChars.class),
+            Arguments.of(UNICODE_MESSAGE, Unicode.uni.class),
+            Arguments.of(CONFLICTING_NAME_MESSAGE, ConflictingNameOuterClass.ConflictingName.class),
+            Arguments.of(NESTED_CONFLICTING_NAME_MESSAGE,
+                NestedConflictingClassNameOuterClass.Parent.NestedConflictingClassName.class),
+            Arguments.of(NESTING_MESSAGE_PROTO3_MULTIPLE_FILES,
+                com.amazonaws.services.schemaregistry.tests.protobuf.syntax3.multiplefiles.A.B.C.X.D.F.M.class)
+        );
+    }
+
+    private static Stream<Arguments> getDynamicMessageDecoderTestCases() {
+        return Stream.of(
+            Arguments.of(BASIC_REFERENCING_DYNAMIC_MESSAGE, ProtobufMessageType.DYNAMIC_MESSAGE),
+            Arguments.of(createDynamicNRecord(), ProtobufMessageType.DYNAMIC_MESSAGE),
+            Arguments.of(createDynamicProtobufRecord(), ProtobufMessageType.DYNAMIC_MESSAGE),
+            Arguments.of(createDynamicProtobufRecord(), ProtobufMessageType.UNKNOWN)
+        );
     }
 }

--- a/serializer-deserializer/src/test/resources/protobuf/TestMetadata.json
+++ b/serializer-deserializer/src/test/resources/protobuf/TestMetadata.json
@@ -7,5 +7,47 @@
     },
     {
       "fileName": "Basic.proto"
+    },
+    {
+      "fileName": "basicSyntax2.proto"
+    },
+    {
+      "fileName": "basicsyntax3.proto"
+    },
+    {
+      "fileName": "ComplexNestingSyntax3WithMultipleFiles.proto"
+    },
+    {
+      "fileName": "JavaOptionsMultipleFilesSyntax3.proto"
+    },
+    {
+      "fileName": "JAVAOPTIONSSYNTAX3.proto"
+    },
+    {
+      "fileName": "snake_case_file.proto"
+    },
+    {
+      "fileName": "Another_snakeCase_ProtoFile.proto"
+    },
+    {
+      "fileName": ".protodevelasl.proto.proto.protodevel#$---$#$#.bar.3#.proto"
+    },
+    {
+      "fileName": "*&()^#!`~;:\"'{[}}<,>>.special?.proto"
+    },
+    {
+    "fileName": "ConflictingName.proto"
+    },
+    {
+    "fileName": "foo$$$1.proto"
+    },
+    {
+    "fileName": "hyphen-ated-proto_file-.proto"
+    },
+    {
+    "fileName": "NestedConflicting&#$ClassName.proto"
+    },
+    {
+    "fileName": "◉◉◉unicode⏩.proto"
     }
 ]


### PR DESCRIPTION
Adds support for deserializing bytes to Protobuf POJOs. This uses the utility submitted in [PR](https://github.com/awslabs/aws-glue-schema-registry/pull/74). I also tried to refactor some of the tests to make them cleaner.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
