### PR TITLE
Introduce cache to improve Protobuf serializer/de-serializer performance.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <proto-plugin.version>0.6.1</proto-plugin.version>
         <protobuf.version>3.17.0</protobuf.version>
         <square-wireschema.version>3.7.0</square-wireschema.version>
-        <apicurio-registry.version>2.1.0-SNAPSHOT</apicurio-registry.version>
+        <apicurio-registry.version>2.1.2-SNAPSHOT</apicurio-registry.version>
 
         <slf4j.version>1.7.30</slf4j.version>
         <log4j.version>2.13.2</log4j.version>

--- a/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/serializers/protobuf/ProtobufSerializerTest.java
+++ b/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/serializers/protobuf/ProtobufSerializerTest.java
@@ -15,130 +15,156 @@
 package com.amazonaws.services.schemaregistry.serializers.protobuf;
 
 import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
+import com.amazonaws.services.schemaregistry.deserializers.protobuf.ProtobufWireFormatDecoder;
 import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryException;
-import com.amazonaws.services.schemaregistry.tests.protobuf.syntax2.Basic;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
+import com.amazonaws.services.schemaregistry.utils.ProtobufMessageType;
+import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Message;
+import com.squareup.wire.schema.Location;
+import com.squareup.wire.schema.internal.parser.ProtoParser;
+import io.apicurio.registry.utils.protobuf.schema.FileDescriptorUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.ArrayList;
+import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toList;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.ANOTHER_SNAKE_CASE_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.BASIC_REFERENCING_DYNAMIC_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.BASIC_REFERENCING_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.BASIC_SYNTAX2_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.BASIC_SYNTAX3_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.CONFLICTING_NAME_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.DOLLAR_SYNTAX_3_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.DOUBLE_PROTO_WITH_TRAILING_HASH_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.HYPHEN_ATED_PROTO_FILE_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.JAVA_OUTER_CLASS_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.JAVA_OUTER_CLASS_WITH_MULTIPLE_FILES_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.NESTED_CONFLICTING_NAME_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.NESTING_MESSAGE_PROTO2;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.NESTING_MESSAGE_PROTO3;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.NESTING_MESSAGE_PROTO3_MULTIPLE_FILES;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.SNAKE_CASE_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.SPECIAL_CHARS_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.UNICODE_MESSAGE;
+import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufTestCaseReader.getTestCaseByName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ProtobufSerializerTest {
-    private Basic.Address addressPojo = ProtobufGenerator.createCompiledProtobufRecord();
-
     private ProtobufSerializer protobufSerializer =
             new ProtobufSerializer(new GlueSchemaRegistryConfiguration(new HashMap<String, String>() {{
                 put(AWSSchemaRegistryConstants.AWS_REGION, "us-west-2");
             }}));
+    private ProtobufWireFormatDecoder protobufWireFormatDecoder = new ProtobufWireFormatDecoder(new MessageIndexFinder());
 
-    private ProtobufWireFormatEncoder encoder = new ProtobufWireFormatEncoder(new MessageIndexFinder());
-
-    private static List<Arguments> testBasicAddressProtoFileProvider() {
-        List<ProtobufTestCase> testCases =
-                ProtobufTestCaseReader.getTestCasesByNames("Basic.proto");
-        return testCases
-                .stream()
-                .map(Arguments::of)
-                .collect(toList());
+    private static Stream<Arguments> testMessageProvider() {
+        return Stream.of(
+            Arguments.of(BASIC_SYNTAX2_MESSAGE),
+            Arguments.of(BASIC_SYNTAX3_MESSAGE),
+            Arguments.of(BASIC_REFERENCING_MESSAGE),
+            Arguments.of(BASIC_REFERENCING_DYNAMIC_MESSAGE),
+            Arguments.of(JAVA_OUTER_CLASS_MESSAGE),
+            Arguments.of(JAVA_OUTER_CLASS_WITH_MULTIPLE_FILES_MESSAGE),
+            Arguments.of(NESTING_MESSAGE_PROTO3),
+            Arguments.of(NESTING_MESSAGE_PROTO2),
+            Arguments.of(SNAKE_CASE_MESSAGE),
+            Arguments.of(ANOTHER_SNAKE_CASE_MESSAGE),
+            Arguments.of(DOLLAR_SYNTAX_3_MESSAGE),
+            Arguments.of(HYPHEN_ATED_PROTO_FILE_MESSAGE),
+            Arguments.of(DOUBLE_PROTO_WITH_TRAILING_HASH_MESSAGE),
+            Arguments.of(SPECIAL_CHARS_MESSAGE),
+            Arguments.of(UNICODE_MESSAGE),
+            Arguments.of(CONFLICTING_NAME_MESSAGE),
+            Arguments.of(NESTED_CONFLICTING_NAME_MESSAGE),
+            Arguments.of(NESTING_MESSAGE_PROTO3_MULTIPLE_FILES),
+            Arguments.of(ProtobufGenerator.createDynamicNRecord()),
+            Arguments.of(ProtobufGenerator.createDynamicProtobufRecord()),
+            Arguments.of(ProtobufGenerator.createCompiledProtobufRecord()),
+            Arguments.of(ProtobufGenerator.createCompiledProtobufRecord())
+        );
     }
 
-//    private static List<Arguments> testOrderingApplicationProtoFileProvider() {
-//        List<ProtobufTestCase> testCases =
-//                ProtobufTestCaseReader.getTestCasesByNames("OrderingApplication.proto");
-//        return testCases
-//                .stream()
-//                .map(Arguments::of)
-//                .collect(toList());
-//    }
-
-    private static List<Arguments> testDynamicMessageProvider() {
-        List<Descriptors.FieldDescriptor> fieldDescriptorList = Basic.Address.getDescriptor().getFields();
-        List<DynamicMessage>  dynamicMessageList = new ArrayList<>();
-        DynamicMessage addressDynamicMessage = ProtobufGenerator.createDynamicProtobufRecord();
-        dynamicMessageList.add(addressDynamicMessage);
-
-        return dynamicMessageList
-                .stream()
-                .map(Arguments::of)
-                .collect(toList());
+    private static Stream<Arguments> testMessageProviderForCaching() {
+        return Stream.of(
+            Arguments.of(BASIC_SYNTAX2_MESSAGE),
+            Arguments.of(BASIC_SYNTAX3_MESSAGE),
+            Arguments.of(ProtobufGenerator.createDynamicNRecord()),
+            Arguments.of(ProtobufGenerator.createDynamicNRecord()),
+            Arguments.of(BASIC_SYNTAX3_MESSAGE)
+        );
     }
 
+    private static Stream<Arguments> testProtobufSchemaDefinitionProvider() {
+        return Stream.of(
+            Arguments.of(
+                NESTING_MESSAGE_PROTO2, getTestCaseByName("ComplexNestingSyntax2.proto").getRawSchema(), "ComplexNestingSyntax2.proto"
+            ),
+            Arguments.of(
+                NESTING_MESSAGE_PROTO3, getTestCaseByName("ComplexNestingSyntax3.proto").getRawSchema(), "ComplexNestingSyntax3.proto"
+            ),
+            Arguments.of(
+                BASIC_REFERENCING_DYNAMIC_MESSAGE, getTestCaseByName("Basic.proto").getRawSchema(), "Basic.proto"
+            ),
+            Arguments.of(
+                BASIC_SYNTAX3_MESSAGE, getTestCaseByName("basicsyntax3.proto").getRawSchema(), "basicsyntax3"
+            ),
+            Arguments.of(
+                BASIC_SYNTAX2_MESSAGE, getTestCaseByName("basicSyntax2.proto").getRawSchema(), "basicSyntax2"
+            ),
+            Arguments.of(
+                DOUBLE_PROTO_WITH_TRAILING_HASH_MESSAGE, getTestCaseByName(".protodevelasl.proto.proto.protodevel#$---$#$#.bar.3#.proto").getRawSchema(), ".protodevelasl.proto.proto.protodevel#$---$#$#.bar.3#"
+            ),
+            Arguments.of(
+                UNICODE_MESSAGE, getTestCaseByName("◉◉◉unicode⏩.proto").getRawSchema(), "◉◉◉unicode⏩.proto"
+            ),
+            Arguments.of(
+                SPECIAL_CHARS_MESSAGE, getTestCaseByName("*&()^#!`~;:\"'{[}}<,>>.special?.proto").getRawSchema(), "*&()^#!`~;:\"'{[}}<,>>.special?"
+            ),
+            Arguments.of(
+                DOLLAR_SYNTAX_3_MESSAGE, getTestCaseByName("foo$$$1.proto").getRawSchema(), "foo$$$1.proto"
+            ),
+            Arguments.of(
+                ProtobufGenerator.createDynamicProtobufRecord(), getTestCaseByName("Basic.proto").getRawSchema(), "Basic.proto"
+            )
+        );
+    }
 
     @ParameterizedTest
-    @MethodSource("testBasicAddressProtoFileProvider")
-    public void testGetSchemaDefinition_specificAddressPojo(ProtobufTestCase testCase) {
-        //String schema = testCase.getRawSchema();
-        //Temporary schema assignment
-        String schema = "// Proto schema formatted by Wire, do not edit.\n" +
-                "// Source: \n" +
-                "\n" +
-                "package com.amazonaws.services.schemaregistry.tests.protobuf.syntax2;\n" +
-                "\n" +
-                "message Address {\n" +
-                "  required string street = 1;\n" +
-                "\n" +
-                "  optional int32 zip = 2;\n" +
-                "\n" +
-                "  optional string city = 3;\n" +
-                "}\n" +
-                "\n" +
-                "message Customer {\n" +
-                "  required string name = 1;\n" +
-                "}";
+    @MethodSource("testMessageProvider")
+    public void testSerialize_ProducesValidDeserializableBytes_ForAllTypesOfMessages(Message message) throws IOException {
+        byte[] serializedBytes = protobufSerializer.serialize(message);
 
-        //TODO: Complete upon final implementation of getSchemaDefinition() in ProtobufSerializer
-        //Fails because of issues with apicurio library schema extraction
-        assertEquals(schema, protobufSerializer.getSchemaDefinition(addressPojo).trim());
+        DynamicMessage deserializedDynamicMessage =
+            (DynamicMessage) protobufWireFormatDecoder.decode(serializedBytes, getFileDescriptor(message), ProtobufMessageType.DYNAMIC_MESSAGE);
+        Message deserializedPojoMessage =
+            (Message) protobufWireFormatDecoder.decode(serializedBytes, getFileDescriptor(message), ProtobufMessageType.POJO);
+
+        //Assert that the message can de-serialized back into original Message.
+        assertEquals(message, deserializedDynamicMessage);
+        assertEquals(message, deserializedPojoMessage);
     }
 
-    @Test
-//    @MethodSource("testOrderingApplicationProtoFileProvider")
-    public void testGetSchemaDefinition_specificOrderingApplicationPojo() {
-//        String schema = testCase.getRawSchema();
+    @ParameterizedTest
+    @MethodSource("testProtobufSchemaDefinitionProvider")
+    public void testGetSchemaDefinition_GeneratesValidSchemaDefinition_ForAllTypesOfMessages(Message message, String schemaDefinition, String schemaName)
+        throws Descriptors.DescriptorValidationException {
+        String parsedSchemaDefinition = protobufSerializer.getSchemaDefinition(message);
+        String packageName = ProtoParser.Companion.parse(Location.get(""), schemaDefinition).getPackageName();
 
-//        NestedProtobuf.OrderingApplication orderingApplication = NestedProtobuf.OrderingApplication.newBuilder()
-//                .setOrderNo(123456789)
-//                .build();
-        //TODO: Complete upon final implementation of getSchemaDefinition() in ProtobufSerializer
-        //Fails because of issues with apicurio library schema extraction
-        //assertEquals(schema.trim(), protobufSerializer.getSchemaDefinition(orderingApplication).trim());
-    }
+        DescriptorProtos.FileDescriptorProto expectedFileDescriptorProto =
+            FileDescriptorUtils.protoFileToFileDescriptor(schemaDefinition, schemaName, Optional.ofNullable(packageName)).toProto();
 
-    @Test
-    public void testSerialize_badObject_throwsException() {
-        String s = "test";
-        Exception ex = assertThrows(AWSSchemaRegistryException.class, () -> protobufSerializer.serialize(s));
-        assertEquals("Could not serialize from the type provided", ex.getMessage());
-    }
-
-    @Test
-    public void testSerialize_PayloadBytesMatch_specificPojo() {
-        byte[] expectedBytes = encoder.encode(addressPojo,
-                getFileDescriptor(addressPojo));
-        byte[] serializedBytes = protobufSerializer.serialize(addressPojo);
-        assertArrayEquals(expectedBytes, serializedBytes);
-
-        Basic.Address deserializedObject = null;
-
-        //TODO: check serialization by deserializing the byte array
-        try {
-            //deserializedObject = Basic.Address.parseFrom(serializedBytes);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        //assertEquals(deserializedObject, addressPojo);
+        DescriptorProtos.FileDescriptorProto parsedFileDescriptorProto =
+            FileDescriptorUtils.protoFileToFileDescriptor(parsedSchemaDefinition, schemaName, Optional.ofNullable(packageName)).toProto();
+        assertEquals(expectedFileDescriptorProto, parsedFileDescriptorProto);
     }
 
     @Test
@@ -150,26 +176,20 @@ public class ProtobufSerializerTest {
         Integer num = 5;
         ex = assertThrows(AWSSchemaRegistryException.class, () -> protobufSerializer.validate(num));
         assertEquals("Object is not of Message type: class java.lang.Integer", ex.getMessage());
+
+        ex = assertThrows(IllegalArgumentException.class, () -> protobufSerializer.validate(null));
+        assertEquals("object is marked non-null but is null", ex.getMessage());
     }
 
-    //DynamicMessage
-    @ParameterizedTest
-    @MethodSource("testDynamicMessageProvider")
-    public void testSerialize_PayloadBytesMatch_DynamicMessage(DynamicMessage dynamicMessage) {
-        byte[] expectedBytes = encoder.encode(dynamicMessage,
-                getFileDescriptor(dynamicMessage));
-        byte[] serializedBytes = protobufSerializer.serialize(dynamicMessage);
-        assertArrayEquals(expectedBytes, serializedBytes);
+    @Test
+    public void testSerialize_CachesGeneratedSchema_ForSameArguments() {
+        //Get schema definition for repeated messages of different types.
+        testMessageProviderForCaching()
+            .map(Arguments::get)
+            .map(objects -> objects[0])
+            .forEach(protobufSerializer::getSchemaDefinition);
 
-        DynamicMessage deserializedObject;
-
-        //TODO: check serialization by deserializing the byte array
-        try {
-            // deserializedObject = DynamicMessage.parseFrom(TestProtos.SimpleAddress.getDescriptor(), serializedBytes);
-            //assertEquals(addressDynamicMessage, deserializedObject);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        assertEquals(3, protobufSerializer.schemaGeneratorCache.size());
     }
 
     private Descriptors.FileDescriptor getFileDescriptor(Message message) {


### PR DESCRIPTION
Adds cache to improve performance of serializer/de-serializer while parsing schemas of same type.

Tests pass locally due to latest version of apicurio.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
