### PR TITLE
Upgrade to latest versions of Protobuf dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,9 +89,9 @@
         <jackson.version>2.12.2</jackson.version>
         <!-- Protobuf -->
         <proto-plugin.version>0.6.1</proto-plugin.version>
-        <protobuf.version>3.17.0</protobuf.version>
-        <square-wireschema.version>3.7.0</square-wireschema.version>
-        <apicurio-registry.version>2.1.3-SNAPSHOT</apicurio-registry.version>
+        <protobuf.version>3.19.1</protobuf.version>
+        <square-wireschema.version>3.7.1</square-wireschema.version>
+        <apicurio-registry.version>2.1.3.Final</apicurio-registry.version>
 
         <slf4j.version>1.7.30</slf4j.version>
         <log4j.version>2.13.2</log4j.version>
@@ -110,7 +110,7 @@
         <commons.cli.version>1.2</commons.cli.version>
         <awaitility.version>3.0.0</awaitility.version>
         <localstack.utils>0.2.11</localstack.utils>
-        <protobuf.java.version>3.17.3</protobuf.java.version>
+        <protobuf.java.version>3.19.1</protobuf.java.version>
         <localstack.utils>0.2.11</localstack.utils>
     </properties>
 


### PR DESCRIPTION
Upgrading to latest stable versions of Protobuf dependencies.

Build successful on JDK8 and JDK11.

```
mvn clean install -U
```