### PR TITLE
Remove extra text from Protobuf schema generation

### DIFF
--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/protobuf/ProtobufSerializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/protobuf/ProtobufSerializer.java
@@ -122,8 +122,7 @@ public class ProtobufSerializer implements GlueSchemaRegistryDataFormatSerialize
         public String load(@NotNull DescriptorProtos.FileDescriptorProto fileDescriptorProto) {
             final ProtoFileElement schemaElement = FileDescriptorUtils.fileDescriptorToProtoFile(fileDescriptorProto);
             String rawSchema = schemaElement.toSchema();
-            String stripped = "// Proto schema formatted by Wire, do not edit.\n// Source: \n\n";
-            return rawSchema.substring(stripped.length());
+            return rawSchema.replace("// Proto schema formatted by Wire, do not edit.\n// Source: \n\n", "");
         }
     }
 }

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/protobuf/ProtobufSerializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/protobuf/ProtobufSerializer.java
@@ -121,7 +121,9 @@ public class ProtobufSerializer implements GlueSchemaRegistryDataFormatSerialize
         @Override
         public String load(@NotNull DescriptorProtos.FileDescriptorProto fileDescriptorProto) {
             final ProtoFileElement schemaElement = FileDescriptorUtils.fileDescriptorToProtoFile(fileDescriptorProto);
-            return schemaElement.toSchema();
+            String rawSchema = schemaElement.toSchema();
+            String stripped = "// Proto schema formatted by Wire, do not edit.\n// Source: \n\n";
+            return rawSchema.substring(stripped.length());
         }
     }
 }

--- a/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/serializers/protobuf/ProtobufSerializerTest.java
+++ b/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/serializers/protobuf/ProtobufSerializerTest.java
@@ -56,6 +56,7 @@ import static com.amazonaws.services.schemaregistry.serializers.protobuf.Protobu
 import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufGenerator.UNICODE_MESSAGE;
 import static com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufTestCaseReader.getTestCaseByName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ProtobufSerializerTest {
@@ -157,6 +158,7 @@ public class ProtobufSerializerTest {
     public void testGetSchemaDefinition_GeneratesValidSchemaDefinition_ForAllTypesOfMessages(Message message, String schemaDefinition, String schemaName)
         throws Descriptors.DescriptorValidationException {
         String parsedSchemaDefinition = protobufSerializer.getSchemaDefinition(message);
+        assertFalse(parsedSchemaDefinition.contains("// Proto schema formatted by Wire, do not edit.\n// Source: \n\n"));
         String packageName = ProtoParser.Companion.parse(Location.get(""), schemaDefinition).getPackageName();
 
         DescriptorProtos.FileDescriptorProto expectedFileDescriptorProto =


### PR DESCRIPTION
*Issue #, if available:*
*Description of changes:*

To remove extra comments from Protobuf schema generation

*Tests:*
**Unit test:** 
INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializationFacadeTest
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[INFO] Tests run: 465, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 17.106 s - in com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializationFacadeTest
[INFO] Running com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializerDataParserTest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s - in com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializerDataParserTest
[INFO] Running com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializerFactoryTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.045 s - in com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializerFactoryTest
[INFO] Running com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializerImplTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.337 s - in com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializerImplTest
[INFO] Running com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryKafkaDeserializerTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.05 s - in com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryKafkaDeserializerTest
[INFO] Running com.amazonaws.services.schemaregistry.deserializers.SecondaryDeserializerTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.074 s - in com.amazonaws.services.schemaregistry.deserializers.SecondaryDeserializerTest
[INFO] Running com.amazonaws.services.schemaregistry.deserializers.avro.AWSKafkaAvroDeserializerTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.038 s - in com.amazonaws.services.schemaregistry.deserializers.avro.AWSKafkaAvroDeserializerTest
[INFO] Running com.amazonaws.services.schemaregistry.deserializers.avro.AvroDeserializerTest
[INFO] Tests run: 44, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.148 s - in com.amazonaws.services.schemaregistry.deserializers.avro.AvroDeserializerTest
[INFO] Running com.amazonaws.services.schemaregistry.deserializers.avro.AvroRecordTypeTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.amazonaws.services.schemaregistry.deserializers.avro.AvroRecordTypeTest
[INFO] Running com.amazonaws.services.schemaregistry.deserializers.json.JsonDeserializerTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.amazonaws.services.schemaregistry.deserializers.json.JsonDeserializerTest
[INFO] Running com.amazonaws.services.schemaregistry.deserializers.protobuf.ProtobufClassNameTest
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.078 s - in com.amazonaws.services.schemaregistry.deserializers.protobuf.ProtobufClassNameTest
[INFO] Running com.amazonaws.services.schemaregistry.deserializers.protobuf.ProtobufDeserializerTest
[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.742 s - in com.amazonaws.services.schemaregistry.deserializers.protobuf.ProtobufDeserializerTest
[INFO] Running com.amazonaws.services.schemaregistry.deserializers.protobuf.ProtobufWireFormatDecoderTest
[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.789 s - in com.amazonaws.services.schemaregistry.deserializers.protobuf.ProtobufWireFormatDecoderTest
[INFO] Running com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistryKafkaSerializerTest
[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.321 s - in com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistryKafkaSerializerTest
[INFO] Running com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySerializerImplTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in com.amazonaws.services.schemaregistry.serializers.GlueSchemaRegistrySerializerImplTest
[INFO] Running com.amazonaws.services.schemaregistry.serializers.avro.AWSKafkaAvroSerializerTest
[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.223 s - in com.amazonaws.services.schemaregistry.serializers.avro.AWSKafkaAvroSerializerTest
[INFO] Running com.amazonaws.services.schemaregistry.serializers.avro.AvroSerializerTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in com.amazonaws.services.schemaregistry.serializers.avro.AvroSerializerTest
[INFO] Running com.amazonaws.services.schemaregistry.serializers.avro.GlueSchemaRegistrySerializationFacadeTest
[INFO] Tests run: 653, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.423 s - in com.amazonaws.services.schemaregistry.serializers.avro.GlueSchemaRegistrySerializationFacadeTest
[INFO] Running com.amazonaws.services.schemaregistry.serializers.json.JsonDataWithSchemaTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s - in com.amazonaws.services.schemaregistry.serializers.json.JsonDataWithSchemaTest
[INFO] Running com.amazonaws.services.schemaregistry.serializers.json.JsonSerializerTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.038 s - in com.amazonaws.services.schemaregistry.serializers.json.JsonSerializerTest
[INFO] Running com.amazonaws.services.schemaregistry.serializers.json.JsonValidatorTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in com.amazonaws.services.schemaregistry.serializers.json.JsonValidatorTest
[INFO] Running com.amazonaws.services.schemaregistry.serializers.protobuf.MessageIndexFinderTest
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.373 s - in com.amazonaws.services.schemaregistry.serializers.protobuf.MessageIndexFinderTest
[INFO] Running com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufSerializerTest
[INFO] Tests run: 34, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.483 s - in com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufSerializerTest
[INFO] Running com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufWireFormatEncoderTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in com.amazonaws.services.schemaregistry.serializers.protobuf.ProtobufWireFormatEncoderTest
[INFO] Running com.amazonaws.services.schemaregistry.utils.AVROUtilsTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in com.amazonaws.services.schemaregistry.utils.AVROUtilsTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 1424, Failures: 0, Errors: 0, Skipped: 0

**Integration test:**
[INFO] Tests run: 42, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 868.762 s - in com.amazonaws.services.schemaregistry.integrationtests.kafka.GlueSchemaRegistryKafkaIntegrationTest
[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 648.786 s - in com.amazonaws.services.schemaregistry.integrationtests.kinesis.GlueSchemaRegistryKinesisIntegrationTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 70, Failures: 0, Errors: 0, Skipped: 0



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
