### PR TITLE
Fix for: Producer JSON format example

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ The recommended way to use the AWS Glue Schema Registry Library for Java is to c
         String jsonPayload = "{\n" + "        \"employee\": {\n" + "          \"name\": \"John\",\n" + "          \"age\": 30,\n"
                                                  + "          \"city\": \"New York\"\n" + "        }\n" + "      }";
         
-        JsonDataWithSchema jsonSchemaWithData = JsonDataWithSchema.builder(jsonSchema, jsonPayload);
+        JsonDataWithSchema jsonSchemaWithData = JsonDataWithSchema.builder(jsonSchema, jsonPayload).build();
 
         List<JsonDataWithSchema> genericJsonRecords = new ArrayList<>();
         genericJsonRecords.add(jsonSchemaWithData);


### PR DESCRIPTION
This is a small fix for the documentation - for the producer json format example after I have tried it.

*Issue #, if available:*
error: incompatible types: JsonDataWithSchemaBuilder cannot be converted to JsonDataWithSchema

*Description of changes:*
I have added .build() to the JsonDataWithSchema.builder at the end since without it we will get the above exception


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
