### PR TITLE
Support for assuming role for schema registry operations when using kafka connect

### DIFF
--- a/avro-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/AWSKafkaAvroConverter.java
+++ b/avro-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/AWSKafkaAvroConverter.java
@@ -29,6 +29,11 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.storage.Converter;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 import java.util.Map;
 
@@ -74,6 +79,26 @@ public class AWSKafkaAvroConverter implements Converter {
     public void configure(Map<String, ?> configs, boolean isKey) {
         this.isKey = isKey;
         new AWSKafkaAvroConverterConfig(configs);
+        final String roleArn = configs.get("sts.roleArn") == null
+                ? null : String.valueOf(configs.get("sts.roleArn"));
+        final String roleSessionName = configs.get("sts.roleSessionName") == null
+                ? null : String.valueOf(configs.get("sts.roleSessionName"));
+        if (roleArn != null && roleSessionName != null) {
+            AwsCredentialsProvider credentialsProvider = StsAssumeRoleCredentialsProvider.builder()
+                    .stsClient(StsClient.builder()
+                            .httpClient(UrlConnectionHttpClient.builder().build())
+                            .build())
+                    .refreshRequest(AssumeRoleRequest.builder()
+                            .roleArn(roleArn)
+                            .roleSessionName(roleSessionName)
+                            .build())
+                    .build();
+            serializer = new AWSKafkaAvroSerializer(credentialsProvider, null, null);
+            serializer.setUserAgentApp(UserAgents.KAFKACONNECT);
+
+            deserializer = new AWSKafkaAvroDeserializer(credentialsProvider, null);
+            deserializer.setUserAgentApp(UserAgents.KAFKACONNECT);
+        }
 
         serializer.configure(configs, this.isKey);
         deserializer.configure(configs, this.isKey);

--- a/avro-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/AWSKafkaAvroConverter.java
+++ b/avro-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/AWSKafkaAvroConverter.java
@@ -47,8 +47,9 @@ import java.util.Map;
 @Slf4j
 @Data
 public class AWSKafkaAvroConverter implements Converter {
-    private static final String STS_ROLE_ARN = "sts.roleArn";
-    private static final String STS_ROLE_SESSION_NAME = "sts.roleSessionName";
+    private static final String STS_ROLE_ARN = "sts.role.arn";
+    private static final String STS_ROLE_SESSION_NAME = "sts.role.session.name";
+    private static final String STS_ROLE_SESSION_NAME_DEFAULT = "schema-registry-kafkaconnect-converter";
     private AWSKafkaAvroSerializer serializer;
     private AWSKafkaAvroDeserializer deserializer;
     private AvroData avroData;
@@ -87,7 +88,7 @@ public class AWSKafkaAvroConverter implements Converter {
         final String roleArn = configs.get(STS_ROLE_ARN) == null
                 ? null : String.valueOf(configs.get(STS_ROLE_ARN));
         final String roleSessionName = configs.get(STS_ROLE_SESSION_NAME) == null
-                ? null : String.valueOf(configs.get(STS_ROLE_SESSION_NAME));
+                ? STS_ROLE_SESSION_NAME_DEFAULT : String.valueOf(configs.get(STS_ROLE_SESSION_NAME));
         if (roleArn != null && roleSessionName != null) {
             StsClientBuilder stsClientBuilder = StsClient.builder()
                     .httpClient(UrlConnectionHttpClient.builder().build());

--- a/avro-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/AWSKafkaAvroConverterTest.java
+++ b/avro-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/AWSKafkaAvroConverterTest.java
@@ -40,15 +40,14 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.glue.model.DataFormat;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -95,6 +94,21 @@ public class AWSKafkaAvroConverterTest {
         assertNotNull(converter);
         assertNotNull(converter.getSerializer());
         assertNotNull(converter.getDeserializer());
+        assertNotNull(converter.getAvroData());
+    }
+
+    @Test
+    public void testConverter_configure_usesStsCredentialsProvider() {
+        converter = new AWSKafkaAvroConverter();
+        Map<String, Object> props = getProperties();
+        props.put("sts.roleArn", "TEST_ROLE_ARN");
+        props.put("sts.roleSessionName", "TEST_ROLE_SESSION_NAME");
+        converter.configure(props, false);
+        assertNotNull(converter);
+        assertNotNull(converter.getSerializer());
+        assertTrue(converter.getSerializer().getCredentialProvider() instanceof StsAssumeRoleCredentialsProvider);
+        assertNotNull(converter.getDeserializer());
+        assertTrue(converter.getDeserializer().getCredentialProvider() instanceof StsAssumeRoleCredentialsProvider);
         assertNotNull(converter.getAvroData());
     }
 

--- a/avro-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/AWSKafkaAvroConverterTest.java
+++ b/avro-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/AWSKafkaAvroConverterTest.java
@@ -101,8 +101,8 @@ public class AWSKafkaAvroConverterTest {
     public void testConverter_configure_usesStsCredentialsProvider() {
         converter = new AWSKafkaAvroConverter();
         Map<String, Object> props = getProperties();
-        props.put("sts.roleArn", "TEST_ROLE_ARN");
-        props.put("sts.roleSessionName", "TEST_ROLE_SESSION_NAME");
+        props.put("sts.role.arn", "TEST_ROLE_ARN");
+        props.put("sts.role.session.name", "TEST_ROLE_SESSION_NAME");
         converter.configure(props, false);
         assertNotNull(converter);
         assertNotNull(converter.getSerializer());


### PR DESCRIPTION
### Context

* I imagine it's relatively common to share a schema registry among multiple AWS accounts within an organization necessitating cross account access to schema registries.
* Glue Registry does not support resource permissions so cross account have to be used to access schema registries.
* There's currently no way to assume cross account roles when using `AWSKafkaAvroConverter`

### Changes

This PR adds two new configuration parameters used in `AWSKafkaAvroConverter`:
* `sts.roleArn` provides a role ARN to be used when using an AWS glue schema registry
* `sts.roleSessionName` provides a role session name to be used when using an AWS glue schema registry

When both parameters are provided the `AWSKafkaAvroConverter` constructs an `StsAssumeRoleCredentialsProvider` to be used when accessing the registry schema.