### PR TITLE
Upgrade kotlin dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,8 @@
         <jackson.version>2.12.2</jackson.version>
         <!-- Protobuf -->
         <proto-plugin.version>0.6.1</proto-plugin.version>
-        <protobuf.version>3.19.2</protobuf.version>
+	<protobuf.version>3.19.2</protobuf.version>
+	<kotlin.version>1.7.10</kotlin.version>
         <square-wireschema.version>3.7.1</square-wireschema.version>
         <apicurio-registry.version>2.1.3.Final</apicurio-registry.version>
 

--- a/serializer-deserializer/pom.xml
+++ b/serializer-deserializer/pom.xml
@@ -106,7 +106,12 @@
             <artifactId>protobuf-java</artifactId>
             <version>${protobuf.version}</version>
         </dependency>
-        <dependency>
+	<dependency>
+	    <groupId>org.jetbrains.kotlin</groupId>
+	    <artifactId>kotlin-stdlib</artifactId>
+	    <version>1.7.10</version>
+	</dependency>
+	<dependency>
             <groupId>com.squareup.wire</groupId>
             <artifactId>wire-schema</artifactId>
             <version>${square-wireschema.version}</version>

--- a/serializer-deserializer/pom.xml
+++ b/serializer-deserializer/pom.xml
@@ -109,7 +109,32 @@
 	<dependency>
 	    <groupId>org.jetbrains.kotlin</groupId>
 	    <artifactId>kotlin-stdlib</artifactId>
-	    <version>1.7.10</version>
+	    <version>${kotlin.version}</version>
+	</dependency>
+	<dependency>
+	    <groupId>org.jetbrains.kotlin</groupId>
+	    <artifactId>kotlin-stdlib-jdk8</artifactId>
+	    <version>${kotlin.version}</version>
+    	</dependency>
+	<dependency>
+	    <groupId>org.jetbrains.kotlin</groupId>
+	    <artifactId>kotlin-reflect</artifactId>
+	    <version>${kotlin.version}</version>
+	</dependency>
+	<dependency>
+	    <groupId>org.jetbrains.kotlin</groupId>
+	    <artifactId>kotlin-scripting-compiler-impl-embeddable</artifactId>
+	    <version>${kotlin.version}</version>
+    	</dependency>
+	<dependency>
+	    <groupId>org.jetbrains.kotlin</groupId>
+	    <artifactId>kotlin-scripting-compiler-embeddable</artifactId>
+	    <version>${kotlin.version}</version>
+	</dependency>
+	<dependency>
+	    <groupId>org.jetbrains.kotlinx</groupId>
+	    <artifactId>kotlinx-serialization-core-jvm</artifactId>
+	    <version>1.4.0</version>
 	</dependency>
 	<dependency>
             <groupId>com.squareup.wire</groupId>


### PR DESCRIPTION
*Description of changes:*
Upgrade kotlin-stdlib version to 1.7.10. Wire-schema and wire-compiler version 3.7.1 pull kotlin-stdlib 1.4.10 which has vulnerabilities. Wire-schema and wire-compiler version 4.0.0 and above introduce breaking changes so we're directly specifying kotlin-stdlib version instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
