### PR TITLE
Upgrade Evrit Json Schema to prevent cve-2020-15250

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,3 +59,6 @@ GlueSchemaRegistryKafkaSerializer/GlueSchemaRegistryKafkaDeserializer.
 
 ## Release 1.1.13
 * Upgraded kotlin dependency versions to prevent a CVE
+
+## [Unreleased]
+* Upgraded Evrit Json Schema version to prevent a CVE

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -10,7 +10,7 @@ https://github.com/confluentinc/schema-registry/tree/master/avro-serializer
 ** Jackson; version 2.11.3 -- https://github.com/FasterXML/jackson
 ** LocalStack Java Utils : version 0.2.10 -- https://github.com/localstack/localstack-java-utils
 ** Awaitility : version 3.0.0 -- https://github.com/awaitility/awaitility
-** Ever-it JSON Schema 1.12.2 -- https://github.com/everit-org/json-schema
+** Ever-it JSON Schema 1.14.1 -- https://github.com/everit-org/json-schema
 ** MongoDB Kafka Connector 1.3.0-all -- https://github.com/mongodb/mongo-kafka
 ** Connect JSON Schema Compatibility -- https://github.com/rayokota/json-schema-compatibility/blob/master/json-schema-converter/src/main/java/io/yokota/json/connect/JsonSchemaConverter.java
 ** Square Wire -- https://github.com/square/wire/tree/master/wire-library/wire-schema

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <kafka.version>2.8.1</kafka.version>
         <avro.version>1.11.0</avro.version>
         <mbknor.jsonschema.converter.version>1.0.39</mbknor.jsonschema.converter.version>
-        <everit.json.schema.version>1.12.2</everit.json.schema.version>
+        <everit.json.schema.version>1.14.1</everit.json.schema.version>
         <classgraph.version>4.8.120</classgraph.version>
         <commons.compress.version>1.21</commons.compress.version>
         <commons.lang.version>3.8.1</commons.lang.version>


### PR DESCRIPTION
*Issue #, if available:*
Issue [220](https://github.com/awslabs/aws-glue-schema-registry/issues/220)
*Description of changes:*

bumping `everit.json.schema` to 1.14.1 to prevent [CVE](https://nvd.nist.gov/vuln/detail/cve-2020-15250)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
