### PR TITLE
Upgrade dependency versions to avoid potential vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,14 +85,14 @@
         <kafka.version>2.8.1</kafka.version>
         <avro.version>1.11.0</avro.version>
         <mbknor.jsonschema.converter.version>1.0.39</mbknor.jsonschema.converter.version>
-        <everit.json.schema.version>1.12.2</everit.json.schema.version>
+        <everit.json.schema.version>1.14.1</everit.json.schema.version>
         <classgraph.version>4.8.120</classgraph.version>
         <commons.compress.version>1.21</commons.compress.version>
         <commons.lang.version>3.8.1</commons.lang.version>
         <jackson.version>2.12.2</jackson.version>
         <!-- Protobuf -->
         <proto-plugin.version>0.6.1</proto-plugin.version>
-	<protobuf.version>3.19.2</protobuf.version>
+	<protobuf.version>3.19.6</protobuf.version>
 	<kotlin.version>1.7.10</kotlin.version>
         <square-wireschema.version>3.7.1</square-wireschema.version>
         <apicurio-registry.version>2.1.3.Final</apicurio-registry.version>
@@ -114,7 +114,7 @@
         <commons.cli.version>1.2</commons.cli.version>
         <awaitility.version>3.0.0</awaitility.version>
         <localstack.utils>0.2.11</localstack.utils>
-        <protobuf.java.version>3.19.2</protobuf.java.version>
+        <protobuf.java.version>3.19.6</protobuf.java.version>
         <localstack.utils>0.2.11</localstack.utils>
     </properties>
 


### PR DESCRIPTION
*Issue #:* #223 #221

*Description of changes:*
1. Upgrade `everit-json-schema` version from `1.12.2` to `1.14.1` to address https://nvd.nist.gov/vuln/detail/cve-2020-15250
2. Upgrade Protobuf version from `3.19.2` to `3.19.6` to address https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3171


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
