### PR TITLE
Fix failing KPL canary tests

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -172,6 +172,11 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
         </dependency>
+	<dependency>
+	    <groupId>javax.xml.bind</groupId>
+	    <artifactId>jaxb-api</artifactId>
+	    <version>2.3.1</version>
+    	</dependency>
         <!-- Dependency on test jar for test data -->
         <dependency>
             <groupId>software.amazon.glue</groupId>


### PR DESCRIPTION
*Description of changes:*
Adding `javax.xml.bind:jaxb-api` dependency to integration tests pom to fix failing KPL canary tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
