### PR TITLE
Update squareio wire-schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,9 +95,8 @@
         <proto-plugin.version>0.6.1</proto-plugin.version>
 	<protobuf.version>3.19.6</protobuf.version>
 	<kotlin.version>1.7.10</kotlin.version>
-        <square-wireschema.version>3.7.1</square-wireschema.version>
-        <apicurio-registry.version>2.4.1.Final</apicurio-registry.version>
-
+        <square-wireschema.version>4.3.0</square-wireschema.version>
+        <apicurio-registry.version>2.1.3.Final</apicurio-registry.version>
         <slf4j.version>1.7.30</slf4j.version>
         <log4j.version>2.17.1</log4j.version>
         <jupiter.version>5.6.2</jupiter.version>

--- a/serializer-deserializer/pom.xml
+++ b/serializer-deserializer/pom.xml
@@ -135,6 +135,16 @@
 	    <artifactId>kotlin-scripting-compiler-embeddable</artifactId>
 	    <version>${kotlin.version}</version>
 	</dependency>
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio-fakefilesystem</artifactId>
+            <version>3.2.0</version>
+        </dependency>
 	<dependency>
 	    <groupId>org.jetbrains.kotlinx</groupId>
 	    <artifactId>kotlinx-serialization-core-jvm</artifactId>

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/apicurio/ProtobufSchemaLoader.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/apicurio/ProtobufSchemaLoader.java
@@ -22,10 +22,6 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.io.CharStreams;
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Feature;
-import com.google.common.jimfs.Jimfs;
-import com.google.common.jimfs.PathType;
 import com.squareup.wire.schema.Location;
 import com.squareup.wire.schema.ProtoFile;
 import com.squareup.wire.schema.Schema;
@@ -34,12 +30,14 @@ import com.squareup.wire.schema.SchemaLoader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.file.FileSystem;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
+
+import okio.Buffer;
+import okio.Path;
+import okio.Sink;
+import okio.fakefilesystem.FakeFileSystem;
 
 public class ProtobufSchemaLoader {
 
@@ -85,15 +83,10 @@ public class ProtobufSchemaLoader {
     private final static String METADATA_PROTO = "metadata.proto";
     private final static String DECIMAL_PROTO = "decimal.proto";
 
-    private static FileSystem getFileSystem() throws IOException {
-        final FileSystem inMemoryFileSystem =
-            Jimfs.newFileSystem(
-                Configuration.builder(PathType.unix())
-                    .setRoots("/")
-                    .setWorkingDirectory("/")
-                    .setAttributeViews("basic")
-                    .setSupportedFeatures(Feature.SYMBOLIC_LINKS)
-                    .build());
+    private static FakeFileSystem getFileSystem() throws IOException {
+        final FakeFileSystem inMemoryFileSystem = new FakeFileSystem();
+        inMemoryFileSystem.setWorkingDirectory(Path.get("/"));
+        inMemoryFileSystem.setAllowSymlinks(true);
 
         final ClassLoader classLoader = ProtobufSchemaLoader.class.getClassLoader();
 
@@ -112,35 +105,47 @@ public class ProtobufSchemaLoader {
         return inMemoryFileSystem;
     }
 
-    private static void loadProtoFiles(FileSystem inMemoryFileSystem, ClassLoader classLoader, Set<String> protos,
+
+    private static void loadProtoFiles(FakeFileSystem inMemoryFileSystem, ClassLoader classLoader, Set<String> protos,
                                        String protoPath)
             throws IOException {
         for (String proto : protos) {
             //Loads the proto file resource files.
             final InputStream inputStream = classLoader.getResourceAsStream(protoPath + proto);
             final String fileContents = CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
-            final Path path = inMemoryFileSystem.getPath("/", protoPath, proto);
-            Files.write(path, fileContents.getBytes());
+            final Path dir = Path.get("/").resolve(protoPath);
+            inMemoryFileSystem.createDirectories(dir);
+            byte[] bytes = fileContents.getBytes();
+            Path path = dir.resolve(proto);
+            writeToFakeFileSystem(inMemoryFileSystem, bytes, path);
         }
     }
 
-    private static String createDirectory(String[] dirs, FileSystem fileSystem) throws IOException {
-        String dirPath = "";
-        for (String dir: dirs) {
-            dirPath = dirPath + "/" + dir;
-            Path path = fileSystem.getPath(dirPath);
-            if (Files.notExists(path)) {
-                Files.createDirectory(path);
-            }
-        }
+    private static void writeToFakeFileSystem(FakeFileSystem inMemoryFileSystem, byte[] bytes, Path path) throws IOException {
+        Buffer buffer = new Buffer();
+        buffer.write(bytes);
+        Sink sink = inMemoryFileSystem.sink(path);
+        sink.write(
+                buffer,
+                bytes.length);
+        sink.flush();
+        sink.close();
+    }
 
-        return dirPath;
+    private static Path createDirectory(String[] dirs, FakeFileSystem fileSystem) throws IOException {
+        Path path = Path.get("/");
+        for (String dir: dirs) {
+            path = path.resolve(dir);
+        }
+        fileSystem.createDirectories(path);
+        return path;
     }
 
     /**
      * Creates a schema loader using a in-memory file system. This is required for square wire schema parser and linker
      * to load the types correctly. See https://github.com/square/wire/issues/2024#
      * As of now this only supports reading one .proto file but can be extended to support reading multiple files.
+     *
      * @param packageName Package name for the .proto if present
      * @param fileName Name of the .proto file.
      * @param schemaDefinition Schema Definition to parse.
@@ -148,7 +153,7 @@ public class ProtobufSchemaLoader {
      */
     public static ProtobufSchemaLoaderContext loadSchema(Optional<String> packageName, String fileName, String schemaDefinition)
         throws IOException {
-        final FileSystem inMemoryFileSystem = getFileSystem();
+        final FakeFileSystem inMemoryFileSystem = getFileSystem();
 
         String [] dirs = {};
         if (packageName.isPresent()) {
@@ -156,11 +161,11 @@ public class ProtobufSchemaLoader {
         }
         String protoFileName = fileName.endsWith(".proto") ? fileName : fileName + ".proto";
         try {
-            String dirPath = createDirectory(dirs, inMemoryFileSystem);
-            Path path = inMemoryFileSystem.getPath(dirPath, protoFileName);
-            Files.write(path, schemaDefinition.getBytes());
+            Path dirPath = createDirectory(dirs, inMemoryFileSystem);
+            Path path = dirPath.resolve(protoFileName);
+            writeToFakeFileSystem(inMemoryFileSystem, schemaDefinition.getBytes(), path);
 
-            try (SchemaLoader schemaLoader = new SchemaLoader(inMemoryFileSystem)) {
+            SchemaLoader schemaLoader = new SchemaLoader(inMemoryFileSystem);
                 schemaLoader.initRoots(Lists.newArrayList(Location.get("/")), Lists.newArrayList(Location.get("/")));
 
                 Schema schema = schemaLoader.loadSchema();
@@ -171,11 +176,8 @@ public class ProtobufSchemaLoader {
                 }
 
                 return new ProtobufSchemaLoaderContext(schema, protoFile);
-            }
         } catch (Exception e) {
             throw e;
-        } finally {
-            inMemoryFileSystem.close();
         }
     }
 


### PR DESCRIPTION
*Issue*

This library depends on wireschema 3.7.1 when confluent protobuf deserializer depends on 4.3.0. This make it impossible to use both in the same project.
Here is my proposal to update wireschema to make both libraries compatible.
I didn't update to 4.4.3 (latest) because there is also breaking change between 4.3.0 and 4.4.0

*Description of changes:*

- use okio FakeSystem instead of jimfs ProtobufSchemaLoader (see: https://github.com/square/wire/pull/1918)

