### PR TITLE
Implement logical types conversion for serializer/deserializer

### DIFF
--- a/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
@@ -68,6 +68,8 @@ public class GlueSchemaRegistryConfiguration {
     private List<SerializationFeature> jacksonSerializationFeatures;
     private List<DeserializationFeature> jacksonDeserializationFeatures;
 
+    private boolean logicalTypesConversionEnabled;
+
     public GlueSchemaRegistryConfiguration(String region) {
         Map<String, Object> config = new HashMap<>();
         config.put(AWSSchemaRegistryConstants.AWS_REGION, region);
@@ -104,6 +106,7 @@ public class GlueSchemaRegistryConfiguration {
         validateAndSetUserAgent(configs);
         validateAndSetSecondaryDeserializer(configs);
         validateAndSetProxyUrl(configs);
+        validateAndSetLogicalTypesConversionEnabled(configs);
     }
 
     private void validateAndSetSecondaryDeserializer(Map<String, ?> configs) {
@@ -127,6 +130,12 @@ public class GlueSchemaRegistryConfiguration {
     private void validateAndSetUserAgent(Map<String, ?> configs) {
         if (isPresent(configs, AWSSchemaRegistryConstants.USER_AGENT_APP)) {
             this.userAgentApp = (String) configs.get(AWSSchemaRegistryConstants.USER_AGENT_APP);
+        }
+    }
+
+    private void validateAndSetLogicalTypesConversionEnabled(Map<String, ?> configs) {
+        if (isPresent(configs, AWSSchemaRegistryConstants.LOGICAL_TYPES_CONVERSION_ENABLED)) {
+            this.logicalTypesConversionEnabled = (Boolean) configs.get(AWSSchemaRegistryConstants.LOGICAL_TYPES_CONVERSION_ENABLED);
         }
     }
 

--- a/common/src/main/java/com/amazonaws/services/schemaregistry/utils/AWSSchemaRegistryConstants.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/utils/AWSSchemaRegistryConstants.java
@@ -173,6 +173,11 @@ public final class AWSSchemaRegistryConstants {
     public static final String USER_AGENT_APP = "userAgentApp";
 
     /**
+     * Boolean indicating if logical types in avro data must be converted or not.
+     */
+    public static final String LOGICAL_TYPES_CONVERSION_ENABLED = "logicalTypesConversionEnabled";
+
+    /**
      * Private constructor to avoid initialization of the class.
      */
 

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/avro/AvroDeserializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/avro/AvroDeserializer.java
@@ -51,6 +51,9 @@ public class AvroDeserializer implements GlueSchemaRegistryDataFormatDeserialize
     @Setter
     private AvroRecordType avroRecordType;
 
+    @Setter
+    private boolean logicalTypesConversionEnabled;
+
     @NonNull
     @Getter
     @VisibleForTesting
@@ -65,6 +68,7 @@ public class AvroDeserializer implements GlueSchemaRegistryDataFormatDeserialize
     public AvroDeserializer(GlueSchemaRegistryConfiguration configs) {
         this.schemaRegistrySerDeConfigs = configs;
         this.avroRecordType = configs.getAvroRecordType();
+        this.logicalTypesConversionEnabled = configs.isLogicalTypesConversionEnabled();
         this.datumReaderCache =
             CacheBuilder
                 .newBuilder()
@@ -111,7 +115,7 @@ public class AvroDeserializer implements GlueSchemaRegistryDataFormatDeserialize
     private class DatumReaderCache extends CacheLoader<String, DatumReader<Object>> {
         @Override
         public DatumReader<Object> load(String schema) throws Exception {
-            return DatumReaderInstance.from(schema, avroRecordType);
+            return DatumReaderInstance.from(schema, avroRecordType, logicalTypesConversionEnabled);
         }
     }
 }

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/avro/DatumReaderInstance.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/avro/DatumReaderInstance.java
@@ -29,7 +29,7 @@ public class DatumReaderInstance {
      * @throws IllegalAccessException can be thrown readerClass.newInstance() from
      *                                java.lang.Class implementation
      */
-    public static DatumReader<Object> from(String writerSchemaDefinition, AvroRecordType avroRecordType)
+    public static DatumReader<Object> from(String writerSchemaDefinition, AvroRecordType avroRecordType, boolean logicalTypesConversionEnabled)
         throws InstantiationException, IllegalAccessException {
 
         Schema writerSchema = AVRO_UTILS.parseSchema(writerSchemaDefinition);
@@ -47,7 +47,11 @@ public class DatumReaderInstance {
             case GENERIC_RECORD:
                 log.debug("Using GenericDatumReader for de-serializing Avro message, schema: {})",
                     writerSchema.toString());
-                return new GenericDatumReader<>(writerSchema);
+                if (logicalTypesConversionEnabled) {
+                    return new GenericDatumReader<>(writerSchema, writerSchema, GenericDataWithLogicalTypesConversion.getInstance());
+                } else {
+                    return new GenericDatumReader<>(writerSchema);
+                }
 
             default:
                 String message = String.format("Unsupported AvroRecordType: %s",

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/avro/GenericDataWithLogicalTypesConversion.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/avro/GenericDataWithLogicalTypesConversion.java
@@ -1,0 +1,27 @@
+package com.amazonaws.services.schemaregistry.deserializers.avro;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.Conversions;
+import org.apache.avro.data.TimeConversions;
+import org.apache.avro.generic.GenericData;
+
+@Slf4j
+public class GenericDataWithLogicalTypesConversion {
+    private static final GenericData INSTANCE = new GenericData();
+
+    static {
+        INSTANCE.addLogicalTypeConversion(new Conversions.DecimalConversion());
+        INSTANCE.addLogicalTypeConversion(new Conversions.UUIDConversion());
+        INSTANCE.addLogicalTypeConversion(new TimeConversions.DateConversion());
+        INSTANCE.addLogicalTypeConversion(new TimeConversions.TimeMillisConversion());
+        INSTANCE.addLogicalTypeConversion(new TimeConversions.TimeMicrosConversion());
+        INSTANCE.addLogicalTypeConversion(new TimeConversions.LocalTimestampMillisConversion());
+        INSTANCE.addLogicalTypeConversion(new TimeConversions.LocalTimestampMicrosConversion());
+        INSTANCE.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
+        INSTANCE.addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());
+    }
+
+    public static GenericData getInstance() {
+        return INSTANCE;
+    }
+}

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/GlueSchemaRegistrySerializerFactory.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/GlueSchemaRegistrySerializerFactory.java
@@ -45,7 +45,7 @@ public class GlueSchemaRegistrySerializerFactory {
                                                               @NonNull GlueSchemaRegistryConfiguration glueSchemaRegistryConfig) {
         switch (dataFormat) {
             case AVRO:
-                this.serializerMap.computeIfAbsent(dataFormat, key -> new AvroSerializer());
+                this.serializerMap.computeIfAbsent(dataFormat, key -> new AvroSerializer(glueSchemaRegistryConfig));
 
                 log.debug("Returning Avro serializer instance from GlueSchemaRegistrySerializerFactory");
                 return this.serializerMap.get(dataFormat);

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/avro/DatumWriterInstance.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/avro/DatumWriterInstance.java
@@ -1,5 +1,6 @@
 package com.amazonaws.services.schemaregistry.serializers.avro;
 
+import com.amazonaws.services.schemaregistry.deserializers.avro.GenericDataWithLogicalTypesConversion;
 import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryException;
 import com.amazonaws.services.schemaregistry.utils.AvroRecordType;
 import org.apache.avro.Schema;
@@ -8,12 +9,16 @@ import org.apache.avro.io.DatumWriter;
 import org.apache.avro.specific.SpecificDatumWriter;
 
 public class DatumWriterInstance {
-    public static DatumWriter<Object> get(Schema schema, AvroRecordType avroRecordType) {
+    public static DatumWriter<Object> get(Schema schema, AvroRecordType avroRecordType, boolean logicalTypesConversionEnabled) {
         switch (avroRecordType) {
             case SPECIFIC_RECORD:
                 return new SpecificDatumWriter<>(schema);
             case GENERIC_RECORD:
-                return new GenericDatumWriter<>(schema);
+                if (logicalTypesConversionEnabled) {
+                    return new GenericDatumWriter<>(schema, GenericDataWithLogicalTypesConversion.getInstance());
+                } else {
+                    return new GenericDatumWriter<>(schema);
+                }
             case UNKNOWN:
             default:
                 String message =

--- a/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/serializers/avro/AvroSerializerTest.java
+++ b/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/serializers/avro/AvroSerializerTest.java
@@ -1,8 +1,12 @@
 package com.amazonaws.services.schemaregistry.serializers.avro;
 
+import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
+import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import com.amazonaws.services.schemaregistry.utils.RecordGenerator;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -10,7 +14,8 @@ public class AvroSerializerTest {
 
     @Test
     public void serialize_WhenSerializeIsCalled_ReturnsCachedInstance() {
-        AvroSerializer avroSerializer = new AvroSerializer();
+        GlueSchemaRegistryConfiguration config = new GlueSchemaRegistryConfiguration("eu-west-1");
+        AvroSerializer avroSerializer = new AvroSerializer(config);
 
         User specificUserRecord = RecordGenerator.createSpecificAvroRecord();
         GenericRecord genericUserRecord = RecordGenerator.createGenericUserMapAvroRecord();

--- a/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/utils/RecordGenerator.java
+++ b/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/utils/RecordGenerator.java
@@ -22,7 +22,9 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 
+import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -42,6 +44,7 @@ public final class RecordGenerator {
     public static final String AVRO_USER_ARRAY_STRING_SCHEMA_FILE = "src/test/resources/avro/user_array_String.avsc";
     public static final String AVRO_USER_MAP_SCHEMA_FILE = "src/test/resources/avro/user_map.avsc";
     public static final String AVRO_USER_MIXED_TYPE_SCHEMA_FILE = "src/test/resources/avro/user3.avsc";
+    public static final String AVRO_USER_LOGICAL_TYPES_SCHEMA_FILE_PATH = "src/test/resources/avro/user4.avsc";
     public static final String JSON_PERSON_SCHEMA_FILE_PATH =
             "src/test/resources/json/schema/draft07/person.schema.json";
     public static final String JSON_PERSON_DATA_FILE_PATH = "src/test/resources/json/person1.json";
@@ -320,6 +323,21 @@ public final class RecordGenerator {
         genericRecordWithAllTypes.put("integerEnum", k);
 
         return genericRecordWithAllTypes;
+    }
+
+    /**
+     * Test Helper method to generate a test GenericRecord with logical types
+     *
+     * @return Generic AVRO Record
+     */
+    public static GenericRecord createGenericAvroRecordWithLogicalTypes() {
+        Schema schema = SchemaLoader.loadAvroSchema(AVRO_USER_LOGICAL_TYPES_SCHEMA_FILE_PATH);
+        GenericRecord genericRecord = new GenericData.Record(schema);
+        genericRecord.put("name", "Sylvestre");
+        genericRecord.put("dateOfBirth", LocalDate.parse("2021-05-01"));
+        genericRecord.put("age", new BigDecimal("1.56"));
+
+        return genericRecord;
     }
 
     /**

--- a/serializer-deserializer/src/test/resources/avro/user4.avsc
+++ b/serializer-deserializer/src/test/resources/avro/user4.avsc
@@ -1,0 +1,10 @@
+{
+  "namespace": "com.amazonaws.services.schemaregistry.serializers.avro",
+  "type": "record",
+  "name": "User4",
+  "fields": [
+      {"name": "name", "type": "string" },
+      {"name": "dateOfBirth", "type": { "type": "int", "logicalType": "date"} },
+      {"name": "age", "type": { "type": "bytes", "logicalType": "decimal", "precision": 12, "scale": 2 } }
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I noticed that the glue serializer / deserializer was not handling logical types conversions. 
This PR aims to add support for those conversions. I added a boolean in the configuration class to let the user define if he wants to enable conversions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
