### PR TITLE
Fix build failure on windows runners.

### DIFF
--- a/.github/workflows/MavenCI.yml
+++ b/.github/workflows/MavenCI.yml
@@ -6,9 +6,9 @@ on:
   pull_request:
     branches: [ master ]
   release:
-    branches: [ master ] 
-    types: [ created ]  
-    
+    branches: [ master ]
+    types: [ created ]
+
 jobs:
   build:
     runs-on: ${{ matrix.operating-system }}
@@ -23,27 +23,21 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java-version }}
-    
+
     - name: Cache Maven packages
       uses: actions/cache@v2
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
-        
-    - name: install build-tools 
-      run: mvn --file build-tools/pom.xml clean install
-    
-    - name: Clean, build and install 
+
+    - name: Clean, build and install
       run: mvn --file pom.xml clean install
-    
-    - name: Run tests
-      run: mvn --file pom.xml test
-    
+
     - name: Build package
       run: mvn -B package --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -400,13 +400,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.1.2</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>${project.groupId}</groupId>
-                        <artifactId>schema-registry-build-tools</artifactId>
-                        <version>${project.version}</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
                     <excludes>**/apicurio/**, **/additionalTypes/**, **/metadata/**</excludes>
                     <suppressionsFileExpression>checkstyle.suppression.filter</suppressionsFileExpression>


### PR DESCRIPTION
build-tools doesn't need to be a dependency for the plugin as plugin config is referencing the files directly using absolute path. This is causing problem when the underlying .m2 directory is ephemeral between actions steps and the installed jar is lost which causes the next step (clean install) to fail. Also removing `mvn test` step as per maven lifecycle previous `mvn install` already runs the `test` phase.