### PR TITLE
Add a dummy file in the serializer-deserializer-msk-iam module for javadoc and source jar generation

### DIFF
--- a/serializer-deserializer-msk-iam/src/main/java/com/amazonaws/services/schemaregistry/Dummy.java
+++ b/serializer-deserializer-msk-iam/src/main/java/com/amazonaws/services/schemaregistry/Dummy.java
@@ -1,0 +1,7 @@
+package com.amazonaws.services.schemaregistry;
+
+/**
+ * This is just a dummy file created so the Javadoc jar and Source jar will be successfully generated for release
+ * */
+public class Dummy {
+}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
We need to include a dummy java file in the msk-iam module so its javadoc and source jar will be generated. These jars are required for release to Maven central.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
