### PR TITLE
Update to the latest everit-json-schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <kafka.version>2.8.2</kafka.version>
         <avro.version>1.11.1</avro.version>
         <mbknor.jsonschema.converter.version>1.0.39</mbknor.jsonschema.converter.version>
-        <everit.json.schema.version>1.14.1</everit.json.schema.version>
+        <everit.json.schema.version>1.14.2</everit.json.schema.version>
         <classgraph.version>4.8.120</classgraph.version>
         <commons.compress.version>1.21</commons.compress.version>
         <commons.lang.version>3.8.1</commons.lang.version>


### PR DESCRIPTION
Version 1.14.1 of `everit-json-schema` pulls in `org.json:json:20220320` which is covered by `The JSON License`.

Version 1.14.2 of `everit-json-schema` pulls in `org.json:json:20230227` which has been updated to have a `Public Domain` license (see [this commit](https://github.com/stleary/JSON-java/commit/6daabb43ab2d32974f2a8ea79d713f67f4c22d30)).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
