### PR TITLE
Remove url-connector http lib dependency, require GlueClientBuilder input to AWSSchemaRegistryClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,8 @@ GlueSchemaRegistryKafkaSerializer/GlueSchemaRegistryKafkaDeserializer.
 
 ## Release 1.1.15
 * Upgrade Avro, Apicurio and Localhost utils versions
+
+## Release 2.0.0
+* Add GlueClientBuilder as an argument to AWSSchemaRegistryClient
+* Remove url-connection-client as a runtime dependency
+* Remove proxyUrl from accessible configuration

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -75,10 +75,6 @@
             <artifactId>aws-json-protocol</artifactId>
         </dependency>
         <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>url-connection-client</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <!-- Temporarily excluding old version of transitive dependency to fix security bug in underlying library. Remove when dependency is upgraded. -->

--- a/common/src/test/java/com/amazonaws/services/schemaregistry/common/AWSSchemaRegistryClientTest.java
+++ b/common/src/test/java/com/amazonaws/services/schemaregistry/common/AWSSchemaRegistryClientTest.java
@@ -140,13 +140,6 @@ public class AWSSchemaRegistryClientTest {
     }
 
     @Test
-    public void testConstructor_nullCredentials_throwsException() {
-        glueSchemaRegistryConfiguration = new GlueSchemaRegistryConfiguration(configs);
-        Assertions.assertThrows(IllegalArgumentException.class , () -> new AWSSchemaRegistryClient(null,
-            glueSchemaRegistryConfiguration));
-    }
-
-    @Test
     public void testConstructor_nullSerdeConfigs_throwsException() {
         AwsCredentialsProvider mockAwsCredentialsProvider = mock(AwsCredentialsProvider.class);
         Assertions.assertThrows(IllegalArgumentException.class , () -> new AWSSchemaRegistryClient(mockAwsCredentialsProvider,null ));
@@ -154,7 +147,7 @@ public class AWSSchemaRegistryClientTest {
 
     @Test
     public void testConstructor_nullGlueClient_throwsException() {
-        Assertions.assertThrows(IllegalArgumentException.class , () -> new AWSSchemaRegistryClient(null));
+        Assertions.assertThrows(IllegalArgumentException.class , () -> new AWSSchemaRegistryClient((GlueClient) null));
     }
 
     @Test

--- a/common/src/test/java/com/amazonaws/services/schemaregistry/common/UserAgentRequestInterceptorTest.java
+++ b/common/src/test/java/com/amazonaws/services/schemaregistry/common/UserAgentRequestInterceptorTest.java
@@ -13,6 +13,8 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.ApiName;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.GlueClientBuilder;
 import software.amazon.awssdk.services.glue.model.GetSchemaVersionRequest;
 
 import java.util.stream.Stream;
@@ -56,19 +58,17 @@ public class UserAgentRequestInterceptorTest {
     @MethodSource("getClientConfigTestCases")
     void test_UserAgentInterceptor_ReturnsSdkRequestWithUserAgent(GlueSchemaRegistryConfiguration config,
         String expectedName) {
-        AwsCredentialsProvider mockAwsCredentialsProvider = mock(AwsCredentialsProvider.class);
-
         AWSSchemaRegistryClient awsSchemaRegistryClient =
-            new AWSSchemaRegistryClient(mockAwsCredentialsProvider, config);
+            new AWSSchemaRegistryClient(GlueClient.builder(), config);
 
-        AWSSchemaRegistryClient.UserAgentRequestInterceptor userAgentRequestInterceptor =
+        AWSSchemaRegistryClient.UserAgentRequestInterceptor schemaRegistryClientVersionUserAgentAppenderRequestInterceptor =
             awsSchemaRegistryClient.new UserAgentRequestInterceptor();
 
         Context.ModifyRequest modifyRequest = mock(Context.ModifyRequest.class);
         GetSchemaVersionRequest glueRequest = GetSchemaVersionRequest.builder().build();
         doReturn(glueRequest).when(modifyRequest).request();
 
-        SdkRequest sdkHttpRequest = userAgentRequestInterceptor.modifyRequest(modifyRequest, null);
+        SdkRequest sdkHttpRequest = schemaRegistryClientVersionUserAgentAppenderRequestInterceptor.modifyRequest(modifyRequest, null);
         assertNotNull(sdkHttpRequest);
         assertTrue(sdkHttpRequest.overrideConfiguration().isPresent());
 
@@ -80,19 +80,17 @@ public class UserAgentRequestInterceptorTest {
 
     @Test
     void test_UserAgentInterceptor_ReturnsSameRequestForNonGlueRequests() {
-        AwsCredentialsProvider mockAwsCredentialsProvider = mock(AwsCredentialsProvider.class);
-
         AWSSchemaRegistryClient awsSchemaRegistryClient =
-            new AWSSchemaRegistryClient(mockAwsCredentialsProvider, new GlueSchemaRegistryConfiguration(REGION));
+            new AWSSchemaRegistryClient(GlueClient.builder(), new GlueSchemaRegistryConfiguration(REGION));
 
-        AWSSchemaRegistryClient.UserAgentRequestInterceptor userAgentRequestInterceptor =
+        AWSSchemaRegistryClient.UserAgentRequestInterceptor schemaRegistryClientVersionUserAgentAppenderRequestInterceptor =
             awsSchemaRegistryClient.new UserAgentRequestInterceptor();
 
         SdkRequest nonGlueRequest = mock(SdkRequest.class);
         Context.ModifyRequest modifyRequest = mock(Context.ModifyRequest.class);
         doReturn(nonGlueRequest).when(modifyRequest).request();
 
-        SdkRequest actualRequest = userAgentRequestInterceptor.modifyRequest(modifyRequest, null);
+        SdkRequest actualRequest = schemaRegistryClientVersionUserAgentAppenderRequestInterceptor.modifyRequest(modifyRequest, null);
 
         assertEquals(nonGlueRequest, actualRequest);
     }

--- a/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kafka/GlueSchemaRegistryKafkaIntegrationTest.java
+++ b/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kafka/GlueSchemaRegistryKafkaIntegrationTest.java
@@ -43,7 +43,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.glue.model.Compatibility;
@@ -116,8 +115,6 @@ public class GlueSchemaRegistryKafkaIntegrationTest {
                 .credentialsProvider(awsCredentialsProvider)
                 .region(Region.of(REGION))
                 .endpointOverride(new URI(SCHEMA_REGISTRY_ENDPOINT_OVERRIDE))
-                .httpClient(UrlConnectionHttpClient.builder()
-                                    .build())
                 .build();
 
         for (String schemaName : schemasToCleanUp) {

--- a/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kinesis/GlueSchemaRegistryKinesisIntegrationTest.java
+++ b/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kinesis/GlueSchemaRegistryKinesisIntegrationTest.java
@@ -57,7 +57,6 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.SdkSystemSetting;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
@@ -195,8 +194,6 @@ public class GlueSchemaRegistryKinesisIntegrationTest {
                 .credentialsProvider(awsCredentialsProvider)
                 .region(Region.of(REGION))
                 .endpointOverride(new URI(SCHEMA_REGISTRY_ENDPOINT_OVERRIDE))
-                .httpClient(UrlConnectionHttpClient.builder()
-                                    .build())
                 .build();
 
         for (String schemaName : schemasToCleanUp) {

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/GlueSchemaRegistrySerializationFacade.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/GlueSchemaRegistrySerializationFacade.java
@@ -15,7 +15,6 @@
 package com.amazonaws.services.schemaregistry.serializers;
 
 import com.amazonaws.services.schemaregistry.common.AWSSchemaRegistryClient;
-import com.amazonaws.services.schemaregistry.common.AWSSchemaRegistryGlueClientRetryPolicyHelper;
 import com.amazonaws.services.schemaregistry.common.AWSSerializerInput;
 import com.amazonaws.services.schemaregistry.common.GlueSchemaRegistryDataFormatSerializer;
 import com.amazonaws.services.schemaregistry.common.Schema;
@@ -65,8 +64,7 @@ public class GlueSchemaRegistrySerializationFacade {
 
         if (this.schemaByDefinitionFetcher == null) {
             final AWSSchemaRegistryClient client =
-                new AWSSchemaRegistryClient(credentialProvider, this.glueSchemaRegistryConfiguration,
-                    AWSSchemaRegistryGlueClientRetryPolicyHelper.getRetryPolicy());
+                new AWSSchemaRegistryClient(credentialProvider, this.glueSchemaRegistryConfiguration);
             this.schemaByDefinitionFetcher = new SchemaByDefinitionFetcher(client, this.glueSchemaRegistryConfiguration);
         }
 


### PR DESCRIPTION
Issue: https://github.com/awslabs/aws-glue-schema-registry/issues/120 (Primary)

Description: 
AWSSchemaRegistryClient in the `common` module directly imports the UrlConnectionHttpClient, which can cause classpath friction with AWS SDK in other places where ApacheHttpClient is preferred, and the ServiceLoader can't figure out which client to use. An example of this is when using the Kinesis Client Library v2, their addition of this library pollutes the classpath, when it ideally should've waited for a user to deliberately configure in the UrlConnectionHttpClient through a GlueClient. This change prefers rely on the GlueClient defaults, or gives the user _full_ access to the GlueClient builder. It still reserves the right to add some overrides around endpoint, region, etc.

This does break the bespoke integration with the UrlConnection Proxy Url, and now requires manually configuring the Glue Client. This may further impact scenarios where Proxy Url was specified using one of the higher-order libraries around `common`, where the user expects GlueSchemaRegistryConfiguration to set everything up. Now, to create an object like `GlueSchemaRegistrySerializationFacade`, the user has to also create `SchemaByDefinitionFetcher` which then wraps `AWSSchemaRegistryClient` which then wraps `GlueClient` which contains a manually configured UrlConnectionHttpClient with a proxy url.

The url-connection http lib was likely unintentionally added in https://github.com/awslabs/aws-glue-schema-registry/pull/49/files#diff-79d226ed87c480fcfac3a55dfae33d93c29b6b43f7eebbb1369a4557581431bd, and the proxy url functionality was cemented on in https://github.com/awslabs/aws-glue-schema-registry/pull/246. It's worth noting that the initial issue, https://github.com/awslabs/aws-glue-schema-registry/issues/245, was attempting to directly insert a GlueClient, so this is more cohesive with their initial approach.

Related reports of issue:
https://github.com/awslabs/aws-glue-schema-registry/pull/127
https://stackoverflow.com/a/75323773

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
