### PR TITLE
Use default region provider chain

### DIFF
--- a/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.EnumUtils;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.glue.model.Compatibility;
 
 import java.net.URI;
@@ -150,7 +152,15 @@ public class GlueSchemaRegistryConfiguration {
         if (isPresent(configs, AWSSchemaRegistryConstants.AWS_REGION)) {
             this.region = String.valueOf(configs.get(AWSSchemaRegistryConstants.AWS_REGION));
         } else {
-            throw new AWSSchemaRegistryException("Region is not defined in the properties");
+            try {
+                this.region = DefaultAwsRegionProviderChain
+                    .builder()
+                    .build()
+                    .getRegion()
+                    .id();
+            } catch (SdkClientException ex) {
+                throw new AWSSchemaRegistryException("Region is not defined in the properties", ex);
+            }
         }
     }
 

--- a/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
+++ b/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -104,11 +105,27 @@ public class GlueSchemaRegistryConfigurationTest {
     }
 
     /**
+     * Tests configuration for region value via default AWS region provider chain
+     */
+    @Test
+    public void testBuildConfig_regionConfigsSuppliedUsingAwsProvider_thenUseDefaultAwsRegionProviderChain() {
+        Map<String, Object> configWithoutRegion = new HashMap<>();
+        configWithoutRegion.put(AWSSchemaRegistryConstants.AWS_ENDPOINT, "https://test/");
+        System.setProperty("aws.region", "us-west-2");
+
+        GlueSchemaRegistryConfiguration glueSchemaRegistryConfiguration = new GlueSchemaRegistryConfiguration(configWithoutRegion);
+
+        assertEquals("us-west-2", glueSchemaRegistryConfiguration.getRegion());
+
+        System.clearProperty("aws.region");
+    }
+
+    /**
      * Tests configuration for region value
      */
     @Test
     public void testBuildConfig_withRegionConfig_Instantiates() {
-        assertNotNull(new GlueSchemaRegistryConfiguration("us-west-1"));
+        assertDoesNotThrow(() -> new GlueSchemaRegistryConfiguration("us-west-1"));
     }
 
     /**


### PR DESCRIPTION
Closes #279 

If the `AWSSchemaRegistryConstants.AWS_REGION` property is not present, it attempts to use `DefaultAwsRegionProviderChain` to determine the AWS region. This is backwards compatible: the `AWSSchemaRegistryConstants.AWS_REGION` takes precedence, and throws the `AWSSchemaRegistryException` if unable to determine the region.

