### PR TITLE
Fix canary runs to run with fixed Kafka version docker image

### DIFF
--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ALLOW_ANONYMOUS_LOGIN=yes
 
   kafka:
-    image: 'public.ecr.aws/bitnami/kafka:latest'
+    image: 'public.ecr.aws/bitnami/kafka:2.8'
     ports:
       - '9092:9092'
     links:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fixed the version of Kafka docker image to run with 2.8 since there are incompatible changes in the latest versions.
We will in future create more runs to cover multiple kafka version tests. So far this is just a docker image issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
