### PR TITLE
Update kafka dependencies version and bump library version to v1.1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,3 +70,6 @@ GlueSchemaRegistryKafkaSerializer/GlueSchemaRegistryKafkaDeserializer.
 ## Release 1.1.16
 * Upgraded Wire version
 * Excluded some transitive dependencies that are having vulnerabilities
+
+## Release 1.1.17
+* Upgrage kafka dependencies version

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The recommended way to use the AWS Glue Schema Registry Library for Java is to c
   <dependency>
       <groupId>software.amazon.glue</groupId>
       <artifactId>schema-registry-serde</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
   </dependency>
   ```
 ### Code Example
@@ -490,7 +490,7 @@ It should look like this
 * If using bash, run the below commands to set-up your CLASSPATH in your bash_profile. (For any other shell, update the environment accordingly.)
   ```bash
       echo 'export GSR_LIB_BASE_DIR=<>' >>~/.bash_profile
-      echo 'export GSR_LIB_VERSION=1.1.16' >>~/.bash_profile
+      echo 'export GSR_LIB_VERSION=1.1.17' >>~/.bash_profile
       echo 'export KAFKA_HOME=<your kafka installation directory>' >>~/.bash_profile
       echo 'export CLASSPATH=$CLASSPATH:$GSR_LIB_BASE_DIR/avro-kafkaconnect-converter/target/schema-registry-kafkaconnect-converter-$GSR_LIB_VERSION.jar:$GSR_LIB_BASE_DIR/common/target/schema-registry-common-$GSR_LIB_VERSION.jar:$GSR_LIB_BASE_DIR/avro-serializer-deserializer/target/schema-registry-serde-$GSR_LIB_VERSION.jar' >>~/.bash_profile
       source ~/.bash_profile
@@ -549,7 +549,7 @@ It should look like this
   <dependency>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-kafkastreams-serde</artifactId>
-        <version>1.1.16</version>
+        <version>1.1.17</version>
   </dependency>
   ```
 
@@ -587,7 +587,7 @@ repository for the latest support: [Avro SerializationSchema and Deserialization
   <dependency>
        <groupId>software.amazon.glue</groupId>
        <artifactId>schema-registry-flink-serde</artifactId>
-       <version>1.1.16</version>
+       <version>1.1.17</version>
   </dependency>
   ```
 ### Code Example

--- a/avro-flink-serde/pom.xml
+++ b/avro-flink-serde/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>software.amazon.glue</groupId>
     <artifactId>schema-registry-flink-serde</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
     <name>AWS Glue Schema Registry Flink Avro Serialization Deserialization Schema</name>
     <description>The AWS Glue Schema Registry Library for Apache Flink enables Java developers to easily integrate
         their Apache Flink applications with AWS Glue Schema Registry
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-serde</artifactId>
-            <version>1.1.16</version>
+            <version>1.1.17</version>
         </dependency>
         <dependency>
           <groupId>org.projectlombok</groupId>

--- a/avro-kafkaconnect-converter/pom.xml
+++ b/avro-kafkaconnect-converter/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.16</version>
+        <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.16</version>
+        <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.16</version>
+        <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.16</version>
+        <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.16</version>
+        <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jsonschema-kafkaconnect-converter/pom.xml
+++ b/jsonschema-kafkaconnect-converter/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.16</version>
+        <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kafkastreams-serde/pom.xml
+++ b/kafkastreams-serde/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.16</version>
+        <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>software.amazon.glue</groupId>
     <artifactId>schema-registry-parent</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
     <packaging>pom</packaging>
     <name>AWS Glue Schema Registry Library</name>
     <description>The AWS Glue Schema Registry Library for Java enables Java developers to easily integrate their
@@ -83,7 +83,7 @@
         <aws.sdk.v2.version>2.18.4</aws.sdk.v2.version>
         <aws.sdk.v1.version>1.12.151</aws.sdk.v1.version>
         <kafka.scala.version>2.12</kafka.scala.version>
-        <kafka.version>2.8.2</kafka.version>
+        <kafka.version>3.6.0</kafka.version>
         <avro.version>1.11.1</avro.version>
         <mbknor.jsonschema.converter.version>1.0.39</mbknor.jsonschema.converter.version>
         <everit.json.schema.version>1.14.2</everit.json.schema.version>

--- a/protobuf-kafkaconnect-converter/pom.xml
+++ b/protobuf-kafkaconnect-converter/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.16</version>
+        <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/serializer-deserializer-msk-iam/pom.xml
+++ b/serializer-deserializer-msk-iam/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.16</version>
+        <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/serializer-deserializer/pom.xml
+++ b/serializer-deserializer/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.16</version>
+        <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
*Description of changes:*
Upgrade kafka dependencies to 2.8.2 to 3.6.0
Bump library version from v1.1.16 to v1.1.17


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
