### PR TITLE
fix issue with Avro record default values in Kafka Connect converter

### DIFF
--- a/avro-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/avrodata/AvroData.java
+++ b/avro-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/avrodata/AvroData.java
@@ -1225,7 +1225,7 @@ public class AvroData {
     private Object toConnectData(Schema schema, Object value, ToConnectContext toConnectContext,
                                  boolean doLogicalConversion) {
         validateSchemaValue(schema, value);
-        if (value == null) {
+        if (value == null || value == JsonProperties.NULL_VALUE) {
             return null;
         }
         try {

--- a/avro-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/avrodata/AvroDataTest.java
+++ b/avro-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/avrodata/AvroDataTest.java
@@ -1998,6 +1998,49 @@ public class AvroDataTest {
     }
 
     @Test
+    public void testNestedRecordWithNullDefault() {
+        final String fullSchema = "{"
+                + "  \"name\": \"RecordWithObjectDefault\","
+                + "  \"type\": \"record\","
+                + "  \"fields\": [{"
+                + "    \"name\": \"obj\","
+                + "      \"default\": {\"nullableString\": null},"
+                + "      \"type\": {"
+                + "        \"name\": \"Object\","
+                + "        \"type\": \"record\","
+                + "        \"fields\": [{"
+                + "            \"name\": \"nullableString\","
+                + "            \"type\": [\"null\",\"string\"]}"
+                + "        ]}"
+                + "    }]"
+                + "}";
+
+        org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(fullSchema);
+
+        org.apache.avro.Schema innerSchema = new org.apache.avro.Schema.Parser().parse("{"
+                + "        \"name\": \"Object\","
+                + "        \"type\": \"record\","
+                + "        \"fields\": [{"
+                + "            \"name\": \"nullableString\","
+                + "            \"type\": [\"null\",\"string\"]}"
+                + "        ]}");
+
+        AvroData avroData = new AvroData(0);
+
+        // test record:
+        // {"obj": {"nullableString": null}}
+        GenericRecord nestedRecord = new GenericRecordBuilder(avroSchema)
+                .set("obj", new GenericRecordBuilder(innerSchema).set("nullableString", null).build())
+                .build();
+
+        SchemaAndValue schemaAndValue = avroData.toConnectData(avroSchema, nestedRecord);
+        Struct value = (Struct)schemaAndValue.value();
+        assertNotNull(value.get("obj"));
+        Struct objFieldValue = (Struct)value.get("obj");
+        assertNull(objFieldValue.get("nullableString"));
+    }
+
+    @Test
     public void testArrayOfRecordWithNullNamespace() {
         org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.array().items()
                 .record("item").fields()


### PR DESCRIPTION
*Issue #, if available:* #307

*Description of changes:* See issue for description of the problem. This PR adds a check for `JsonProperties.NULL_VALUE` in addition to `null` to fix this problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.