### PR TITLE
Update the target scala version to 2.13 for mbknor-jackson-jsonschema and kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <glue.schema.registry.groupId>software.amazon.glue</glue.schema.registry.groupId>
         <aws.sdk.v2.version>2.18.4</aws.sdk.v2.version>
         <aws.sdk.v1.version>1.12.151</aws.sdk.v1.version>
-        <kafka.scala.version>2.12</kafka.scala.version>
+        <kafka.scala.version>2.13</kafka.scala.version>
         <kafka.version>3.6.0</kafka.version>
         <avro.version>1.11.3</avro.version>
         <mbknor.jsonschema.converter.version>1.0.39</mbknor.jsonschema.converter.version>

--- a/serializer-deserializer/pom.xml
+++ b/serializer-deserializer/pom.xml
@@ -89,7 +89,7 @@
         </dependency>
         <dependency>
             <groupId>com.kjetland</groupId>
-            <artifactId>mbknor-jackson-jsonschema_2.12</artifactId>
+            <artifactId>mbknor-jackson-jsonschema_${kafka.scala.version}</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>io.github.classgraph</groupId>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating the following libraries to use the version compiled with Scala 2.13.
  1. mbknor-jackson-jsonschema_2.12 
  2. kafka_2.12

*Motivation:*
There is ongoing work to upgrade AWS SDK to V2 for the Apache Spark as tracked in [this Jira](https://issues.apache.org/jira/browse/SPARK-44124). When upgrading the Spark Kinesis connector module (which transitively depends on glue-schema-registry), the GSR library also pulls in `mbknor-jackson-jsonschema_2.12`. However, as Apache Spark 4.0 release will drop support for scala 2.12 ([Jira ticket](https://issues.apache.org/jira/browse/SPARK-44113)), this lib is considered as banned dependency, resulting in build failures. We would need to replace dependencies that are compiled with scala 2.12 within the GSR repository to proceed with the SDK upgrade. Hence this PR. 

Example build failure information:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.3.0:enforce (enforce-versions) on project spark-streaming-kinesis-asl_2.13:
[ERROR] Rule 2: org.apache.maven.enforcer.rules.dependency.BannedDependencies failed with message:
[ERROR] org.apache.spark:spark-streaming-kinesis-asl_2.13:jar:4.0.0-SNAPSHOT
[ERROR]   software.amazon.kinesis:amazon-kinesis-client:jar:2.5.2
[ERROR]     software.amazon.glue:schema-registry-serde:jar:1.1.14
[ERROR]       com.kjetland:mbknor-jackson-jsonschema_2.12:jar:1.0.39 <--- banned via the exclude/include list
```

*Testing:*
1. The unit tests passed with `mvn clean package`
2. Ran integration tests locally using `run-local-tests.sh`. Although there are 3 test failures, these failures are also observed when running against master branch. Hence they should not be caused by this PR.
```
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   GlueSchemaRegistryKafkaIntegrationTest.testKafkaStreamsProcess:397->assertStreamsRecordsEquality:483 
Expected: is <0>
     but: was <6>
[ERROR]   GlueSchemaRegistryKafkaIntegrationTest.testKafkaStreamsProcess:397->assertStreamsRecordsEquality:483 
Expected: is <0>
     but: was <2>
[ERROR]   GlueSchemaRegistryKinesisIntegrationTest.testProduceConsumeWithKPLAndKCL:345->assertKinesisRecords:550 array contents differ at index [0], expected: <{"name": "Sansa", "favorite_number": 99, "favorite_color": "white"}> but was: <{"name": "Hermione", "favorite_number": 1, "favorite_color": "red"}>
[INFO] 
[ERROR] Tests run: 72, Failures: 3, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  22:16 min
[INFO] Finished at: 2023-12-04T09:59:18Z
[INFO] ------------------------------------------------------------------------
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
