### PR TITLE
Append 2.12 suffix to artifactId for all modules

### DIFF
--- a/avro-flink-serde/pom.xml
+++ b/avro-flink-serde/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>software.amazon.glue</groupId>
-    <artifactId>schema-registry-flink-serde</artifactId>
+    <artifactId>schema-registry-flink-serde_2.12</artifactId>
     <version>1.1.17</version>
     <name>AWS Glue Schema Registry Flink Avro Serialization Deserialization Schema</name>
     <description>The AWS Glue Schema Registry Library for Apache Flink enables Java developers to easily integrate
@@ -65,7 +65,7 @@
     <dependencies>
         <dependency>
             <groupId>software.amazon.glue</groupId>
-            <artifactId>schema-registry-serde</artifactId>
+            <artifactId>schema-registry-serde_2.12</artifactId>
             <version>1.1.17</version>
         </dependency>
         <dependency>
@@ -77,7 +77,7 @@
 
         <dependency>
             <groupId>software.amazon.glue</groupId>
-            <artifactId>schema-registry-serde</artifactId>
+            <artifactId>schema-registry-serde_2.12</artifactId>
             <version>1.0.2</version>
             <classifier>tests</classifier>
             <type>test-jar</type>

--- a/avro-kafkaconnect-converter/pom.xml
+++ b/avro-kafkaconnect-converter/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>${parent.groupId}</groupId>
-    <artifactId>schema-registry-kafkaconnect-converter</artifactId>
+    <artifactId>schema-registry-kafkaconnect-converter_2.12</artifactId>
     <version>${parent.version}</version>
     <name>AWS Glue Schema Registry Kafka Connect AVRO Converter</name>
     <description>The AWS Glue Schema Registry Kafka Connect Converter enables Java developers to easily integrate
@@ -31,7 +31,7 @@
 
     <parent>
         <groupId>software.amazon.glue</groupId>
-        <artifactId>schema-registry-parent</artifactId>
+        <artifactId>schema-registry-parent_2.12</artifactId>
         <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
@@ -62,7 +62,7 @@
     <dependencies>
         <dependency>
             <groupId>${parent.groupId}</groupId>
-            <artifactId>schema-registry-serde</artifactId>
+            <artifactId>schema-registry-serde_2.12</artifactId>
             <version>${parent.version}</version>
         </dependency>
         <dependency>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -21,13 +21,13 @@
 
     <parent>
         <groupId>software.amazon.glue</groupId>
-        <artifactId>schema-registry-parent</artifactId>
+        <artifactId>schema-registry-parent_2.12</artifactId>
         <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>${parent.groupId}</groupId>
-    <artifactId>schema-registry-build-tools</artifactId>
+    <artifactId>schema-registry-build-tools_2.12</artifactId>
     <version>${parent.version}</version>
     <name>AWS Glue Schema Registry Build Tools</name>
     <description>The AWS Glue Schema Registry build tools helps run code coverage for AWS Glue Schema Registry Library

--- a/change-scala-version.sh
+++ b/change-scala-version.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2020 Amazon.com, Inc. or its affiliates.
+# Licensed under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+VALID_VERSIONS=( 2.12 2.13 )
+
+usage() {
+  echo "Usage: $(basename $0) [-h|--help] <version>
+where :
+  -h| --help Display this help text
+  valid version values : ${VALID_VERSIONS[*]}
+" 1>&2
+  exit 1
+}
+
+if [[ ($# -ne 1) || ( $1 == "--help") ||  $1 == "-h" ]]; then
+  usage
+fi
+
+TO_VERSION=$1
+
+check_scala_version() {
+  for i in ${VALID_VERSIONS[*]}; do [ $i = "$1" ] && return 0; done
+  echo "Invalid Scala version: $1. Valid versions: ${VALID_VERSIONS[*]}" 1>&2
+  exit 1
+}
+
+check_scala_version "$TO_VERSION"
+
+if [ $TO_VERSION = "2.13" ]; then
+  FROM_VERSION="2.12"
+else
+  FROM_VERSION="2.13"
+fi
+
+sed_i() {
+  sed -e "$1" "$2" > "$2.tmp" && mv "$2.tmp" "$2"
+}
+
+BASEDIR=$(dirname $0)
+for f in $(find "$BASEDIR" -name 'pom.xml' -not -path '*target*'); do
+  echo $f
+  sed_i 's/\(artifactId.*\)_'$FROM_VERSION'/\1_'$TO_VERSION'/g' $f
+done

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,13 +21,13 @@
 
     <parent>
         <groupId>software.amazon.glue</groupId>
-        <artifactId>schema-registry-parent</artifactId>
+        <artifactId>schema-registry-parent_2.12</artifactId>
         <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>${parent.groupId}</groupId>
-    <artifactId>schema-registry-common</artifactId>
+    <artifactId>schema-registry-common_2.12</artifactId>
     <version>${parent.version}</version>
     <name>AWS Glue Schema Registry common</name>
     <description>The AWS Glue Schema Common is the common package used by AWS Glue Schema Registry Library and has
@@ -67,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>${parent.groupId}</groupId>
-            <artifactId>schema-registry-build-tools</artifactId>
+            <artifactId>schema-registry-build-tools_2.12</artifactId>
             <version>${parent.version}</version>
         </dependency>
         <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>${parent.groupId}</groupId>
-    <artifactId>schema-registry-examples</artifactId>
+    <artifactId>schema-registry-examples_2.12</artifactId>
     <version>${parent.version}</version>
     <name>AWS Glue Schema Registry examples</name>
     <description>The AWS Glue Schema examples has sample code for using Schema Registry with different applications.
@@ -30,7 +30,7 @@
 
     <parent>
         <groupId>software.amazon.glue</groupId>
-        <artifactId>schema-registry-parent</artifactId>
+        <artifactId>schema-registry-parent_2.12</artifactId>
         <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
@@ -70,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>${parent.groupId}</groupId>
-            <artifactId>schema-registry-serde</artifactId>
+            <artifactId>schema-registry-serde_2.12</artifactId>
             <version>${parent.version}</version>
         </dependency>
         <dependency>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>${parent.groupId}</groupId>
-    <artifactId>schema-registry-integration-tests</artifactId>
+    <artifactId>schema-registry-integration-tests_2.12</artifactId>
     <version>${parent.version}</version>
     <name>AWS Glue Schema Registry Integration Tests</name>
     <description>The AWS Glue Schema Registry tests would do a sanity check for the schema registry library.
@@ -30,7 +30,7 @@
 
     <parent>
         <groupId>software.amazon.glue</groupId>
-        <artifactId>schema-registry-parent</artifactId>
+        <artifactId>schema-registry-parent_2.12</artifactId>
         <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
@@ -63,12 +63,12 @@
     <dependencies>
         <dependency>
             <groupId>software.amazon.glue</groupId>
-            <artifactId>schema-registry-serde</artifactId>
+            <artifactId>schema-registry-serde_2.12</artifactId>
             <version>${parent.version}</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.glue</groupId>
-            <artifactId>schema-registry-kafkastreams-serde</artifactId>
+            <artifactId>schema-registry-kafkastreams-serde_2.12</artifactId>
             <version>${parent.version}</version>
         </dependency>
         <dependency>
@@ -102,7 +102,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_${kafka.scala.version}</artifactId>
+            <artifactId>kafka_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -184,7 +184,7 @@
         <!-- Dependency on test jar for test data -->
         <dependency>
             <groupId>software.amazon.glue</groupId>
-            <artifactId>schema-registry-serde</artifactId>
+            <artifactId>schema-registry-serde_2.12</artifactId>
             <version>${parent.version}</version>
             <type>test-jar</type>
             <scope>test</scope>

--- a/jsonschema-kafkaconnect-converter/pom.xml
+++ b/jsonschema-kafkaconnect-converter/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>${parent.groupId}</groupId>
-    <artifactId>jsonschema-kafkaconnect-converter</artifactId>
+    <artifactId>jsonschema-kafkaconnect-converter_2.12</artifactId>
     <version>${parent.version}</version>
     <name>AWS Glue Schema Registry Kafka Connect JSONSchema Converter</name>
     <description>The AWS Glue Schema Registry Kafka Connect Converter enables Java developers to easily integrate
@@ -31,7 +31,7 @@
 
     <parent>
         <groupId>software.amazon.glue</groupId>
-        <artifactId>schema-registry-parent</artifactId>
+        <artifactId>schema-registry-parent_2.12</artifactId>
         <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
@@ -62,7 +62,7 @@
     <dependencies>
         <dependency>
             <groupId>${parent.groupId}</groupId>
-            <artifactId>schema-registry-serde</artifactId>
+            <artifactId>schema-registry-serde_2.12</artifactId>
             <version>${parent.version}</version>
         </dependency>
         <dependency>

--- a/kafkastreams-serde/pom.xml
+++ b/kafkastreams-serde/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>${parent.groupId}</groupId>
-    <artifactId>schema-registry-kafkastreams-serde</artifactId>
+    <artifactId>schema-registry-kafkastreams-serde_2.12</artifactId>
     <version>${parent.version}</version>
     <name>AWS Glue Schema Registry Kafka Streams SerDe</name>
     <description>The AWS Glue Schema Registry Kafka Streams SerDe library enables Java developers to easily integrate
@@ -31,7 +31,7 @@
 
     <parent>
         <groupId>software.amazon.glue</groupId>
-        <artifactId>schema-registry-parent</artifactId>
+        <artifactId>schema-registry-parent_2.12</artifactId>
         <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
@@ -62,7 +62,7 @@
     <dependencies>
         <dependency>
             <groupId>${parent.groupId}</groupId>
-            <artifactId>schema-registry-serde</artifactId>
+            <artifactId>schema-registry-serde_2.12</artifactId>
             <version>${parent.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>software.amazon.glue</groupId>
-    <artifactId>schema-registry-parent</artifactId>
+    <artifactId>schema-registry-parent_2.12</artifactId>
     <version>1.1.17</version>
     <packaging>pom</packaging>
     <name>AWS Glue Schema Registry Library</name>
@@ -82,7 +82,7 @@
         <glue.schema.registry.groupId>software.amazon.glue</glue.schema.registry.groupId>
         <aws.sdk.v2.version>2.18.4</aws.sdk.v2.version>
         <aws.sdk.v1.version>1.12.151</aws.sdk.v1.version>
-        <kafka.scala.version>2.12</kafka.scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
         <kafka.version>3.6.0</kafka.version>
         <avro.version>1.11.3</avro.version>
         <mbknor.jsonschema.converter.version>1.0.39</mbknor.jsonschema.converter.version>
@@ -141,7 +141,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka_${kafka.scala.version}</artifactId>
+                <artifactId>kafka_${scala.binary.version}</artifactId>
                 <version>${kafka.version}</version>
             </dependency>
             <dependency>
@@ -238,7 +238,7 @@
             </dependency>
             <dependency>
                 <groupId>com.kjetland</groupId>
-                <artifactId>mbknor-jackson-jsonschema_${kafka.scala.version}</artifactId>
+                <artifactId>mbknor-jackson-jsonschema_${scala.binary.version}</artifactId>
                 <version>${mbknor.jsonschema.converter.version}</version>
             </dependency>
             <!-- Temporarily adding dependency on a transitive dependency to fix security bug in underlying library. Remove when dependency is upgraded. -->
@@ -499,6 +499,18 @@
         </plugins>
     </build>
     <profiles>
+        <profile>
+            <id>scala-2.12</id>
+            <properties>
+                <scala.binary.version>2.12</scala.binary.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>scala-2.13</id>
+            <properties>
+                <scala.binary.version>2.13</scala.binary.version>
+            </properties>
+        </profile>
         <profile>
             <id>publishing</id>
             <build>

--- a/protobuf-kafkaconnect-converter/pom.xml
+++ b/protobuf-kafkaconnect-converter/pom.xml
@@ -21,13 +21,13 @@
 
     <parent>
         <groupId>software.amazon.glue</groupId>
-        <artifactId>schema-registry-parent</artifactId>
+        <artifactId>schema-registry-parent_2.12</artifactId>
         <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>${parent.groupId}</groupId>
-    <artifactId>protobuf-kafkaconnect-converter</artifactId>
+    <artifactId>protobuf-kafkaconnect-converter_2.12</artifactId>
     <version>${parent.version}</version>
     <name>AWS Glue Schema Registry Kafka Connect Converter for Protobuf</name>
     <description>The AWS Glue Schema Registry Kafka Connect Converter enables Java developers to easily integrate
@@ -63,7 +63,7 @@
     <dependencies>
         <dependency>
             <groupId>${parent.groupId}</groupId>
-            <artifactId>schema-registry-serde</artifactId>
+            <artifactId>schema-registry-serde_2.12</artifactId>
             <version>${parent.version}</version>
         </dependency>
         <dependency>

--- a/serializer-deserializer-msk-iam/pom.xml
+++ b/serializer-deserializer-msk-iam/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>${parent.groupId}</groupId>
-    <artifactId>schema-registry-serde-msk-iam</artifactId>
+    <artifactId>schema-registry-serde-msk-iam_2.12</artifactId>
     <name>AWS Glue Schema Registry Serializer Deserializer with MSK IAM Authentication client</name>
     <description>The AWS Glue Schema Registry Serializer/Deserializer enables Java developers to easily integrate
         their Apache Kafka and AWS Kinesis applications with AWS Glue Schema Registry. MSK IAM Authentication client allows
@@ -32,7 +32,7 @@
 
     <parent>
         <groupId>software.amazon.glue</groupId>
-        <artifactId>schema-registry-parent</artifactId>
+        <artifactId>schema-registry-parent_2.12</artifactId>
         <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>${parent.groupId}</groupId>
-            <artifactId>schema-registry-serde</artifactId>
+            <artifactId>schema-registry-serde_2.12</artifactId>
             <version>${parent.version}</version>
         </dependency>
     </dependencies>

--- a/serializer-deserializer/pom.xml
+++ b/serializer-deserializer/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>${parent.groupId}</groupId>
-    <artifactId>schema-registry-serde</artifactId>
+    <artifactId>schema-registry-serde_2.12</artifactId>
     <name>AWS Glue Schema Registry Serializer Deserializer</name>
     <description>The AWS Glue Schema Registry Serializer/Deserializer enables Java developers to easily integrate
         their Apache Kafka and AWS Kinesis applications with AWS Glue Schema Registry
@@ -31,7 +31,7 @@
 
     <parent>
         <groupId>software.amazon.glue</groupId>
-        <artifactId>schema-registry-parent</artifactId>
+        <artifactId>schema-registry-parent_2.12</artifactId>
         <version>1.1.17</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
@@ -72,7 +72,7 @@
         </dependency>
         <dependency>
             <groupId>${parent.groupId}</groupId>
-            <artifactId>schema-registry-common</artifactId>
+            <artifactId>schema-registry-common_2.12</artifactId>
             <version>${parent.version}</version>
         </dependency>
         <dependency>
@@ -89,7 +89,7 @@
         </dependency>
         <dependency>
             <groupId>com.kjetland</groupId>
-            <artifactId>mbknor-jackson-jsonschema_2.12</artifactId>
+            <artifactId>mbknor-jackson-jsonschema_${scala.binary.version}</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>io.github.classgraph</groupId>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change allows glue-schema-registry to publish different version of artifacts based on scala version. With profile scala-2.12, it would compile with mbknor-jackson-jsonschema_2.12 and kafka_2.12; With profile scala-2.13, it would compile with mbknor-jackson-jsonschema_2.13 and kafka_2.13.

  * Append 2.12 suffix to artifactId for all modules
  * Add two maven profiles for Scala 2.12 and 2.13
  * Add a script to change the scala version for all modules

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
