### PR TITLE
Json support for java8 datetimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,26 @@ The recommended way to use the AWS Glue Schema Registry Library for Java is to c
 
 ```
 
+### Jackson Support for Java 8 Date Types in JSON
+
+To support Java 8 Dates in JSON add the [Jackson JSR310 Datatype](https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-jsr310) dependency to implementing project class path.
+
+For example, in a Maven based project include the latest dependency.
+
+```xml
+<dependency>
+    <groupId>com.fasterxml.jackson.datatype</groupId>
+    <artifactId>jackson-datatype-jsr310</artifactId>
+    <version>2.16.1</version>
+</dependency>
+```
+
+Then add the following configuration property to specify the fully qualified class path to the JavaTimeModule like so.
+
+```java
+properties.put(AWSSchemaRegistryConstants.REGISTER_JAVA_TIME_MODULE, "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule");
+```
+
 #### Producer for Kafka with PROTOBUF format
 
 ```java

--- a/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
@@ -330,13 +330,12 @@ public class GlueSchemaRegistryConfiguration {
         if (isPresent(configs, AWSSchemaRegistryConstants.REGISTER_JAVA_TIME_MODULE)) {
             String moduleClassName = String.valueOf(configs.get(AWSSchemaRegistryConstants.REGISTER_JAVA_TIME_MODULE));
             this.javaTimeModuleClass = moduleClassName;
-            loadJavaTimeModule();
         }
     }
 
     public SimpleModule loadJavaTimeModule() {
         try {
-            Class<?> moduleClass = Class.forName(this.javaTimeModuleClass);
+            Class<?> moduleClass = Class.forName(this.getJavaTimeModuleClass());
             return (SimpleModule) moduleClass.getConstructor().newInstance();
         } catch (Exception e) {
             String message = String.format("Invalid JavaTimeModule specified: %s", this.javaTimeModuleClass);

--- a/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
@@ -108,6 +108,7 @@ public class GlueSchemaRegistryConfiguration {
         validateAndSetSecondaryDeserializer(configs);
         validateAndSetProxyUrl(configs);
         validateAndSetJavaTimeModule(configs);
+        validateAndSetObjectMapperFactory(configs);
     }
 
     private void validateAndSetSecondaryDeserializer(Map<String, ?> configs) {

--- a/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
@@ -59,7 +59,7 @@ public class GlueSchemaRegistryConfiguration {
     private Map<String, String> metadata;
     private String secondaryDeserializer;
     private URI proxyUrl;
-    private SimpleModule javaTimeModule;
+    private String javaTimeModuleClass;
 
     /**
      * Name of the application using the serializer/deserializer.
@@ -329,13 +329,18 @@ public class GlueSchemaRegistryConfiguration {
     private void validateAndSetJavaTimeModule(Map<String, ?> configs) {
         if (isPresent(configs, AWSSchemaRegistryConstants.REGISTER_JAVA_TIME_MODULE)) {
             String moduleClassName = String.valueOf(configs.get(AWSSchemaRegistryConstants.REGISTER_JAVA_TIME_MODULE));
-            try {
-                Class<?> moduleClass = Class.forName(moduleClassName);
-                this.javaTimeModule = (SimpleModule) moduleClass.getConstructor().newInstance();
-            } catch (Exception e) {
-                String message = String.format("Invalid JavaTimeModule specified: %s", moduleClassName);
-                throw new AWSSchemaRegistryException(message, e);
-            }
+            this.javaTimeModuleClass = moduleClassName;
+            loadJavaTimeModule();
+        }
+    }
+
+    public SimpleModule loadJavaTimeModule() {
+        try {
+            Class<?> moduleClass = Class.forName(this.javaTimeModuleClass);
+            return (SimpleModule) moduleClass.getConstructor().newInstance();
+        } catch (Exception e) {
+            String message = String.format("Invalid JavaTimeModule specified: %s", this.javaTimeModuleClass);
+            throw new AWSSchemaRegistryException(message, e);
         }
     }
 

--- a/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
@@ -60,6 +60,7 @@ public class GlueSchemaRegistryConfiguration {
     private String secondaryDeserializer;
     private URI proxyUrl;
     private String javaTimeModuleClass;
+    private String objectMapperFactory = "com.amazonaws.services.schemaregistry.utils.json.DefaultObjectMapperFactory";
 
     /**
      * Name of the application using the serializer/deserializer.
@@ -330,6 +331,12 @@ public class GlueSchemaRegistryConfiguration {
         if (isPresent(configs, AWSSchemaRegistryConstants.REGISTER_JAVA_TIME_MODULE)) {
             String moduleClassName = String.valueOf(configs.get(AWSSchemaRegistryConstants.REGISTER_JAVA_TIME_MODULE));
             this.javaTimeModuleClass = moduleClassName;
+        }
+    }
+
+    private void validateAndSetObjectMapperFactory(Map<String, ?> configs) {
+        if (isPresent(configs, AWSSchemaRegistryConstants.OBJECT_MAPPER_FACTORY)) {
+            this.objectMapperFactory = String.valueOf(configs.get(AWSSchemaRegistryConstants.OBJECT_MAPPER_FACTORY));
         }
     }
 

--- a/common/src/main/java/com/amazonaws/services/schemaregistry/utils/AWSSchemaRegistryConstants.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/utils/AWSSchemaRegistryConstants.java
@@ -180,6 +180,12 @@ public final class AWSSchemaRegistryConstants {
     public static final String REGISTER_JAVA_TIME_MODULE = "registerJavaTimeModule";
 
     /**
+     * Factory for creating custom Jackson ObjectMapper instances for use in handling JSON.
+     * Default: com.amazonaws.services.schemaregistry.utils.json.DefaultObjectMapperFactory
+     */
+    public static final String OBJECT_MAPPER_FACTORY = "objectMapperFactory";
+
+    /**
      * Private constructor to avoid initialization of the class.
      */
 

--- a/common/src/main/java/com/amazonaws/services/schemaregistry/utils/AWSSchemaRegistryConstants.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/utils/AWSSchemaRegistryConstants.java
@@ -173,6 +173,13 @@ public final class AWSSchemaRegistryConstants {
     public static final String USER_AGENT_APP = "userAgentApp";
 
     /**
+     * Jackson Java Time Module to use for handling Java 8 Date/Time.
+     * By default, no module is registered.
+     * Ex: com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+     */
+    public static final String REGISTER_JAVA_TIME_MODULE = "registerJavaTimeModule";
+
+    /**
      * Private constructor to avoid initialization of the class.
      */
 

--- a/common/src/test/java/com/amazonaws/services/schemaregistry/common/AWSSchemaRegistryClientTest.java
+++ b/common/src/test/java/com/amazonaws/services/schemaregistry/common/AWSSchemaRegistryClientTest.java
@@ -32,25 +32,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.glue.GlueClient;
-import software.amazon.awssdk.services.glue.model.CreateSchemaRequest;
-import software.amazon.awssdk.services.glue.model.CreateSchemaResponse;
-import software.amazon.awssdk.services.glue.model.DataFormat;
-import software.amazon.awssdk.services.glue.model.EntityNotFoundException;
-import software.amazon.awssdk.services.glue.model.GetSchemaByDefinitionRequest;
-import software.amazon.awssdk.services.glue.model.GetSchemaByDefinitionResponse;
-import software.amazon.awssdk.services.glue.model.GetSchemaVersionRequest;
-import software.amazon.awssdk.services.glue.model.GetSchemaVersionResponse;
-import software.amazon.awssdk.services.glue.model.GetTagsRequest;
-import software.amazon.awssdk.services.glue.model.GetTagsResponse;
-import software.amazon.awssdk.services.glue.model.MetadataKeyValuePair;
-import software.amazon.awssdk.services.glue.model.PutSchemaVersionMetadataRequest;
-import software.amazon.awssdk.services.glue.model.PutSchemaVersionMetadataResponse;
-import software.amazon.awssdk.services.glue.model.QuerySchemaVersionMetadataRequest;
-import software.amazon.awssdk.services.glue.model.QuerySchemaVersionMetadataResponse;
-import software.amazon.awssdk.services.glue.model.RegisterSchemaVersionRequest;
-import software.amazon.awssdk.services.glue.model.RegisterSchemaVersionResponse;
-import software.amazon.awssdk.services.glue.model.RegistryId;
-import software.amazon.awssdk.services.glue.model.SchemaId;
+import software.amazon.awssdk.services.glue.model.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -691,6 +673,18 @@ public class AWSSchemaRegistryClientTest {
 
         String expectedMsg = String.format("Query schema tags:: Call failed while querying tags for schema = %s", testSchemaName);
         assertEquals(expectedMsg, awsSchemaRegistryException.getMessage());
+    }
+
+    @Test
+    public void testCreateSchema_existingSchema_throwsAlreadyExistsException() throws NoSuchFieldException, IllegalAccessException {
+        String testSchemaName = "test-schema";
+        String testSchemaDefinition = "test-schema-definition";
+        awsSchemaRegistryClient = configureAWSSchemaRegistryClientWithSerdeConfig(awsSchemaRegistryClient,
+                glueSchemaRegistryConfiguration);
+
+        when(mockGlueClient.createSchema(any(CreateSchemaRequest.class))).thenThrow(AlreadyExistsException.create("Already exists", null));
+
+        assertThrows(AWSSchemaRegistryException.class, () -> awsSchemaRegistryClient.createSchema(testSchemaName, DataFormat.AVRO.toString(), testSchemaDefinition, getMetadata()));
     }
 
     private Map<String, String> getMetadata() {

--- a/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
+++ b/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
@@ -408,6 +408,15 @@ public class GlueSchemaRegistryConfigurationTest {
     }
 
     @Test
+    public void testBuildConfig_javaTimeModuleEnabledMock_succeeds() {
+        Properties props = createTestProperties();
+        String moduleClassName = "com.amazonaws.services.schemaregistry.common.configs.TestableSimpleModule";
+        props.put(AWSSchemaRegistryConstants.REGISTER_JAVA_TIME_MODULE, moduleClassName);
+        GlueSchemaRegistryConfiguration cfg = new GlueSchemaRegistryConfiguration(props);
+        assertNotNull(cfg.loadJavaTimeModule());
+    }
+
+    @Test
     public void testBuildConfig_javaTimeModuleEnabledWithoutDependency_throwException() {
         Properties props = createTestProperties();
         String moduleClassName = "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule";
@@ -416,5 +425,14 @@ public class GlueSchemaRegistryConfigurationTest {
         Exception exception = assertThrows(AWSSchemaRegistryException.class, () -> cfg.loadJavaTimeModule());
         String message = String.format("Invalid JavaTimeModule specified: %s", moduleClassName);
         assertEquals(message, exception.getMessage());
+    }
+
+    @Test
+    public void testBuildConfig_specifyObjectMapperFactory_succeeds() {
+        Properties props = createTestProperties();
+        String factoryClass = "com.amazonaws.services.schemaregistry.common.configs.TestableSimpleModule"; // could be any string
+        props.put(AWSSchemaRegistryConstants.OBJECT_MAPPER_FACTORY, factoryClass);
+        GlueSchemaRegistryConfiguration cfg = new GlueSchemaRegistryConfiguration(props);
+        assertEquals(factoryClass, cfg.getObjectMapperFactory());
     }
 }

--- a/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
+++ b/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
@@ -408,18 +408,12 @@ public class GlueSchemaRegistryConfigurationTest {
     }
 
     @Test
-    public void testBuildConfig_defaultJavaTimeModule_succeeds() {
-        Properties props = createTestProperties();
-        GlueSchemaRegistryConfiguration glueSchemaRegistryConfiguration = new GlueSchemaRegistryConfiguration(props);
-        assertNull(glueSchemaRegistryConfiguration.loadJavaTimeModule());
-    }
-
-    @Test
     public void testBuildConfig_javaTimeModuleEnabledWithoutDependency_throwException() {
         Properties props = createTestProperties();
         String moduleClassName = "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule";
         props.put(AWSSchemaRegistryConstants.REGISTER_JAVA_TIME_MODULE, moduleClassName);
-        Exception exception = assertThrows(AWSSchemaRegistryException.class, () -> new GlueSchemaRegistryConfiguration(props));
+        GlueSchemaRegistryConfiguration cfg = new GlueSchemaRegistryConfiguration(props);
+        Exception exception = assertThrows(AWSSchemaRegistryException.class, () -> cfg.loadJavaTimeModule());
         String message = String.format("Invalid JavaTimeModule specified: %s", moduleClassName);
         assertEquals(message, exception.getMessage());
     }

--- a/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
+++ b/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
@@ -32,11 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for testing configuration elements.
@@ -409,5 +405,22 @@ public class GlueSchemaRegistryConfigurationTest {
         props.put(AWSSchemaRegistryConstants.PROXY_URL, "http:// proxy.url: 8080");
         Exception exception = assertThrows(AWSSchemaRegistryException.class, () -> new GlueSchemaRegistryConfiguration(props));
         assertEquals("Proxy URL property is not a valid URL: "+proxy, exception.getMessage());
+    }
+
+    @Test
+    public void testBuildConfig_defaultJavaTimeModule_succeeds() {
+        Properties props = createTestProperties();
+        GlueSchemaRegistryConfiguration glueSchemaRegistryConfiguration = new GlueSchemaRegistryConfiguration(props);
+        assertNull(glueSchemaRegistryConfiguration.getJavaTimeModule());
+    }
+
+    @Test
+    public void testBuildConfig_javaTimeModuleEnabledWithoutDependency_throwException() {
+        Properties props = createTestProperties();
+        String moduleClassName = "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule";
+        props.put(AWSSchemaRegistryConstants.REGISTER_JAVA_TIME_MODULE, moduleClassName);
+        Exception exception = assertThrows(AWSSchemaRegistryException.class, () -> new GlueSchemaRegistryConfiguration(props));
+        String message = String.format("Invalid JavaTimeModule specified: %s", moduleClassName);
+        assertEquals(message, exception.getMessage());
     }
 }

--- a/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
+++ b/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
@@ -18,6 +18,8 @@ package com.amazonaws.services.schemaregistry.common.configs;
 import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryException;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import com.amazonaws.services.schemaregistry.utils.AvroRecordType;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -434,5 +436,27 @@ public class GlueSchemaRegistryConfigurationTest {
         props.put(AWSSchemaRegistryConstants.OBJECT_MAPPER_FACTORY, factoryClass);
         GlueSchemaRegistryConfiguration cfg = new GlueSchemaRegistryConfiguration(props);
         assertEquals(factoryClass, cfg.getObjectMapperFactory());
+    }
+
+    @Test
+    public void testBuildConfig_jacksonSerializationFeatures_succeeds() {
+        Properties props = createTestProperties();
+        List<String> features = new ArrayList<>();
+        features.add(SerializationFeature.INDENT_OUTPUT.toString());
+        features.add(SerializationFeature.WRAP_EXCEPTIONS.toString());
+        props.put(AWSSchemaRegistryConstants.JACKSON_SERIALIZATION_FEATURES, features);
+        GlueSchemaRegistryConfiguration cfg = new GlueSchemaRegistryConfiguration(props);
+        assertEquals(cfg.getJacksonSerializationFeatures().size(), 2);
+    }
+
+    @Test
+    public void testBuildConfig_jacksonDeserializationFeatures_succeeds() {
+        Properties props = createTestProperties();
+        List<String> features = new ArrayList<>();
+        features.add(DeserializationFeature.WRAP_EXCEPTIONS.toString());
+        features.add(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES.toString());
+        props.put(AWSSchemaRegistryConstants.JACKSON_DESERIALIZATION_FEATURES, features);
+        GlueSchemaRegistryConfiguration cfg = new GlueSchemaRegistryConfiguration(props);
+        assertEquals(cfg.getJacksonDeserializationFeatures().size(), 2);
     }
 }

--- a/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
+++ b/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
@@ -411,7 +411,7 @@ public class GlueSchemaRegistryConfigurationTest {
     public void testBuildConfig_defaultJavaTimeModule_succeeds() {
         Properties props = createTestProperties();
         GlueSchemaRegistryConfiguration glueSchemaRegistryConfiguration = new GlueSchemaRegistryConfiguration(props);
-        assertNull(glueSchemaRegistryConfiguration.getJavaTimeModule());
+        assertNull(glueSchemaRegistryConfiguration.loadJavaTimeModule());
     }
 
     @Test

--- a/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/TestableSimpleModule.java
+++ b/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/TestableSimpleModule.java
@@ -1,0 +1,6 @@
+package com.amazonaws.services.schemaregistry.common.configs;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public class TestableSimpleModule extends SimpleModule {
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -176,6 +176,10 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
 	<dependency>
 	    <groupId>javax.xml.bind</groupId>
 	    <artifactId>jaxb-api</artifactId>

--- a/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kafka/ObjectMapperDateTimeSupportTest.java
+++ b/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kafka/ObjectMapperDateTimeSupportTest.java
@@ -1,0 +1,71 @@
+package com.amazonaws.services.schemaregistry.integrationtests.kafka;
+
+import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
+import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
+import com.amazonaws.services.schemaregistry.utils.json.ObjectMapperUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ObjectMapperDateTimeSupportTest {
+
+    @Test
+    void testCreate_useJavaTimeModule_succeeds() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(AWSSchemaRegistryConstants.AWS_REGION, "US-West-1");
+        map.put(AWSSchemaRegistryConstants.REGISTER_JAVA_TIME_MODULE, "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule");
+        GlueSchemaRegistryConfiguration cfg = new GlueSchemaRegistryConfiguration(map);
+
+        ObjectMapper om = ObjectMapperUtils.create(cfg);
+        assertNotNull(cfg.loadJavaTimeModule());
+        assertNotNull(om);
+    }
+
+    @Test
+    void testCreate_noJavaTimeModule_failsSerializingJava8DateTime() throws JsonProcessingException {
+        Map<String, Object> map = new HashMap<>();
+        map.put(AWSSchemaRegistryConstants.AWS_REGION, "US-West-1");
+        GlueSchemaRegistryConfiguration cfg = new GlueSchemaRegistryConfiguration(map);
+
+        ObjectMapper om = ObjectMapperUtils.create(cfg);
+
+        MyTestObject myObj = new MyTestObject("obj1", LocalDateTime.now());
+
+        assertThrows(InvalidDefinitionException.class, () -> om.writeValueAsString(myObj));
+    }
+
+    @Test
+    void testCreate_withJavaTimeModule_succeedsSerializingAndDeserializingJava8DateTime() throws JsonProcessingException {
+        Map<String, Object> map = new HashMap<>();
+        map.put(AWSSchemaRegistryConstants.AWS_REGION, "US-West-1");
+        map.put(AWSSchemaRegistryConstants.REGISTER_JAVA_TIME_MODULE, "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule");
+        GlueSchemaRegistryConfiguration cfg = new GlueSchemaRegistryConfiguration(map);
+
+        ObjectMapper om = ObjectMapperUtils.create(cfg);
+
+        MyTestObject expectedObj = new MyTestObject("obj1", LocalDateTime.now());
+        String jsonStr = om.writeValueAsString(expectedObj);
+
+        MyTestObject actualObj = om.readValue(jsonStr, MyTestObject.class);
+        assertNotNull(actualObj);
+        assertEquals(expectedObj.getCreated(), actualObj.getCreated());
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    static class MyTestObject {
+        String name;
+        LocalDateTime created;
+    }
+}

--- a/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kinesis/GlueSchemaRegistryKinesisIntegrationTest.java
+++ b/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kinesis/GlueSchemaRegistryKinesisIntegrationTest.java
@@ -496,7 +496,7 @@ public class GlueSchemaRegistryKinesisIntegrationTest {
             byte[] serializedBytes = dataFormatSerializer.serialize(record);
 
             putFutures.add(producer.addUserRecord(streamName, Long.toString(timestamp.toEpochMilli()), null,
-                                                  ByteBuffer.wrap(serializedBytes), gsrSchema));
+                                                  ByteBuffer.wrap(serializedBytes), null, gsrSchema));
         }
 
         String shardId = null;

--- a/jsonschema-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/FromConnectTest.java
+++ b/jsonschema-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/FromConnectTest.java
@@ -57,7 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class FromConnectTest {
     private static final JsonNodeFactory JSON_NODE_FACTORY = TypeConverter.JSON_NODE_FACTORY;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final JsonValidator JSON_VALIDATOR = new JsonValidator();
+    private static final JsonValidator JSON_VALIDATOR = new JsonValidator(OBJECT_MAPPER);
 
     private ConnectSchemaToJsonSchemaConverter connectSchemaToJsonSchemaConverter;
     private ConnectValueToJsonNodeConverter connectValueToJsonNodeConverter;

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializer.java
@@ -20,6 +20,7 @@ import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDes
 import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryException;
 import com.amazonaws.services.schemaregistry.serializers.json.JsonDataWithSchema;
 import com.amazonaws.services.schemaregistry.common.Schema;
+import com.amazonaws.services.schemaregistry.utils.json.ObjectMapperUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -60,22 +61,7 @@ public class JsonDeserializer implements GlueSchemaRegistryDataFormatDeserialize
     public JsonDeserializer(GlueSchemaRegistryConfiguration configs) {
         this.schemaRegistrySerDeConfigs = configs;
         JsonNodeFactory jsonNodeFactory = JsonNodeFactory.withExactBigDecimals(true);
-        this.objectMapper = new ObjectMapper();
-        this.objectMapper.setNodeFactory(jsonNodeFactory);
-        if (configs != null) {
-            if (!CollectionUtils.isEmpty(configs.getJacksonSerializationFeatures())) {
-                configs.getJacksonSerializationFeatures()
-                        .forEach(this.objectMapper::enable);
-            }
-            if (!CollectionUtils.isEmpty(configs.getJacksonDeserializationFeatures())) {
-                configs.getJacksonDeserializationFeatures()
-                        .forEach(this.objectMapper::enable);
-            }
-            if (configs.getJavaTimeModule() != null) {
-                this.objectMapper.registerModule(configs.getJavaTimeModule());
-                this.objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-            }
-        }
+        this.objectMapper = ObjectMapperUtils.create(configs, jsonNodeFactory);
     }
 
     /**

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializer.java
@@ -22,7 +22,9 @@ import com.amazonaws.services.schemaregistry.serializers.json.JsonDataWithSchema
 import com.amazonaws.services.schemaregistry.common.Schema;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
@@ -32,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 
 /**
@@ -67,6 +70,10 @@ public class JsonDeserializer implements GlueSchemaRegistryDataFormatDeserialize
             if (!CollectionUtils.isEmpty(configs.getJacksonDeserializationFeatures())) {
                 configs.getJacksonDeserializationFeatures()
                         .forEach(this.objectMapper::enable);
+            }
+            if (configs.getJavaTimeModule() != null) {
+                this.objectMapper.registerModule(configs.getJavaTimeModule());
+                this.objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
             }
         }
     }

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializer.java
@@ -23,19 +23,14 @@ import com.amazonaws.services.schemaregistry.common.Schema;
 import com.amazonaws.services.schemaregistry.utils.json.ObjectMapperUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 
 /**
@@ -60,8 +55,7 @@ public class JsonDeserializer implements GlueSchemaRegistryDataFormatDeserialize
     @Builder
     public JsonDeserializer(GlueSchemaRegistryConfiguration configs) {
         this.schemaRegistrySerDeConfigs = configs;
-        JsonNodeFactory jsonNodeFactory = JsonNodeFactory.withExactBigDecimals(true);
-        this.objectMapper = ObjectMapperUtils.create(configs, jsonNodeFactory);
+        this.objectMapper = ObjectMapperUtils.create(configs);
     }
 
     /**

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/json/JsonSerializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/json/JsonSerializer.java
@@ -17,6 +17,7 @@ package com.amazonaws.services.schemaregistry.serializers.json;
 import com.amazonaws.services.schemaregistry.common.GlueSchemaRegistryDataFormatSerializer;
 import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
 import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryException;
+import com.amazonaws.services.schemaregistry.utils.json.ObjectMapperUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -53,22 +54,7 @@ public class JsonSerializer implements GlueSchemaRegistryDataFormatSerializer {
     public JsonSerializer(GlueSchemaRegistryConfiguration configs) {
         this.schemaRegistrySerDeConfigs = configs;
         JsonNodeFactory jsonNodeFactory = JsonNodeFactory.withExactBigDecimals(true);
-        this.objectMapper = new ObjectMapper();
-        this.objectMapper.setNodeFactory(jsonNodeFactory);
-        if (configs != null) {
-            if (!CollectionUtils.isEmpty(configs.getJacksonSerializationFeatures())) {
-                configs.getJacksonSerializationFeatures()
-                        .forEach(this.objectMapper::enable);
-            }
-            if (!CollectionUtils.isEmpty(configs.getJacksonDeserializationFeatures())) {
-                configs.getJacksonDeserializationFeatures()
-                        .forEach(this.objectMapper::enable);
-            }
-            if (configs.getJavaTimeModule() != null) {
-                this.objectMapper.registerModule(configs.getJavaTimeModule());
-                this.objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-            }
-        }
+        this.objectMapper = ObjectMapperUtils.create(configs, jsonNodeFactory);
         this.jsonSchemaGenerator = new JsonSchemaGenerator(this.objectMapper);
     }
 

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/json/JsonSerializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/json/JsonSerializer.java
@@ -20,6 +20,7 @@ import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryExceptio
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator;
 import lombok.Builder;
@@ -62,6 +63,10 @@ public class JsonSerializer implements GlueSchemaRegistryDataFormatSerializer {
             if (!CollectionUtils.isEmpty(configs.getJacksonDeserializationFeatures())) {
                 configs.getJacksonDeserializationFeatures()
                         .forEach(this.objectMapper::enable);
+            }
+            if (configs.getJavaTimeModule() != null) {
+                this.objectMapper.registerModule(configs.getJavaTimeModule());
+                this.objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
             }
         }
         this.jsonSchemaGenerator = new JsonSchemaGenerator(this.objectMapper);

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/json/JsonSerializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/json/JsonSerializer.java
@@ -21,15 +21,12 @@ import com.amazonaws.services.schemaregistry.utils.json.ObjectMapperUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
 
 import java.nio.charset.StandardCharsets;
 
@@ -53,8 +50,7 @@ public class JsonSerializer implements GlueSchemaRegistryDataFormatSerializer {
     @Builder
     public JsonSerializer(GlueSchemaRegistryConfiguration configs) {
         this.schemaRegistrySerDeConfigs = configs;
-        JsonNodeFactory jsonNodeFactory = JsonNodeFactory.withExactBigDecimals(true);
-        this.objectMapper = ObjectMapperUtils.create(configs, jsonNodeFactory);
+        this.objectMapper = ObjectMapperUtils.create(configs);
         this.jsonSchemaGenerator = new JsonSchemaGenerator(this.objectMapper);
     }
 

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/json/JsonSerializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/json/JsonSerializer.java
@@ -35,7 +35,7 @@ import java.nio.charset.StandardCharsets;
  */
 @Slf4j
 public class JsonSerializer implements GlueSchemaRegistryDataFormatSerializer {
-    private static final JsonValidator JSON_VALIDATOR = new JsonValidator();
+    private final JsonValidator jsonValidator;
     private final JsonSchemaGenerator jsonSchemaGenerator;
     private final ObjectMapper objectMapper;
     @Getter
@@ -51,6 +51,7 @@ public class JsonSerializer implements GlueSchemaRegistryDataFormatSerializer {
     public JsonSerializer(GlueSchemaRegistryConfiguration configs) {
         this.schemaRegistrySerDeConfigs = configs;
         this.objectMapper = ObjectMapperUtils.create(configs);
+        this.jsonValidator = new JsonValidator(this.objectMapper);
         this.jsonSchemaGenerator = new JsonSchemaGenerator(this.objectMapper);
     }
 
@@ -67,7 +68,7 @@ public class JsonSerializer implements GlueSchemaRegistryDataFormatSerializer {
 
         final JsonNode dataNode = getDataNode(data);
         final JsonNode schemaNode = getSchemaNode(data);
-        JSON_VALIDATOR.validateDataWithSchema(schemaNode, dataNode);
+        jsonValidator.validateDataWithSchema(schemaNode, dataNode);
 
         bytes = writeBytes(dataNode);
         return bytes;
@@ -169,6 +170,6 @@ public class JsonSerializer implements GlueSchemaRegistryDataFormatSerializer {
     public void validate(Object jsonDataWithSchema) {
         JsonNode schemaNode = getSchemaNode(jsonDataWithSchema);
         JsonNode dataNode = getDataNode(jsonDataWithSchema);
-        JSON_VALIDATOR.validateDataWithSchema(schemaNode, dataNode);
+        jsonValidator.validateDataWithSchema(schemaNode, dataNode);
     }
 }

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/json/JsonValidator.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/json/JsonValidator.java
@@ -30,6 +30,13 @@ import java.io.InputStream;
  * Json validator
  */
 public class JsonValidator {
+
+    private final ObjectMapper mapper;
+
+    public JsonValidator(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
     /**
      * Validates data against JsonSchema
      * @param schemaNode
@@ -37,7 +44,7 @@ public class JsonValidator {
      */
     public void validateDataWithSchema(JsonNode schemaNode, JsonNode dataNode) {
         try {
-            ObjectMapper mapper = new ObjectMapper();
+//            ObjectMapper mapper = new ObjectMapper();
             JSONObject rawSchema = new JSONObject(mapper.writeValueAsString(schemaNode));
             Schema schema = SchemaLoader.load(rawSchema, new ReferenceDisabledSchemaClient());
 

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/json/DefaultObjectMapperFactory.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/json/DefaultObjectMapperFactory.java
@@ -1,0 +1,33 @@
+package com.amazonaws.services.schemaregistry.utils.json;
+
+import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import org.apache.commons.collections4.CollectionUtils;
+
+public class DefaultObjectMapperFactory implements ObjectMapperFactory {
+
+    @Override
+    public ObjectMapper newInstance(GlueSchemaRegistryConfiguration configs) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
+
+        if (configs != null) {
+            if (!CollectionUtils.isEmpty(configs.getJacksonSerializationFeatures())) {
+                configs.getJacksonSerializationFeatures()
+                        .forEach(objectMapper::enable);
+            }
+            if (!CollectionUtils.isEmpty(configs.getJacksonDeserializationFeatures())) {
+                configs.getJacksonDeserializationFeatures()
+                        .forEach(objectMapper::enable);
+            }
+            if (configs.getJavaTimeModuleClass() != null) {
+                objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+                objectMapper.registerModule(configs.loadJavaTimeModule());
+            }
+        }
+
+        return objectMapper;
+    }
+}

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/json/ObjectMapperFactory.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/json/ObjectMapperFactory.java
@@ -1,0 +1,9 @@
+package com.amazonaws.services.schemaregistry.utils.json;
+
+import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public interface ObjectMapperFactory {
+
+    ObjectMapper newInstance(GlueSchemaRegistryConfiguration configs);
+}

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/json/ObjectMapperUtils.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/json/ObjectMapperUtils.java
@@ -1,6 +1,5 @@
 package com.amazonaws.services.schemaregistry.utils.json;
 
-
 import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -9,9 +8,10 @@ import org.apache.commons.collections4.CollectionUtils;
 
 public class ObjectMapperUtils {
 
-    public static ObjectMapper create(GlueSchemaRegistryConfiguration configs, JsonNodeFactory jsonNodeFactory) {
+    public static ObjectMapper create(GlueSchemaRegistryConfiguration configs) {
         ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.setNodeFactory(jsonNodeFactory);
+        objectMapper.setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
+
         if (configs != null) {
             if (!CollectionUtils.isEmpty(configs.getJacksonSerializationFeatures())) {
                 configs.getJacksonSerializationFeatures()

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/json/ObjectMapperUtils.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/json/ObjectMapperUtils.java
@@ -1,0 +1,32 @@
+package com.amazonaws.services.schemaregistry.utils.json;
+
+
+import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import org.apache.commons.collections4.CollectionUtils;
+
+public class ObjectMapperUtils {
+
+    public static ObjectMapper create(GlueSchemaRegistryConfiguration configs, JsonNodeFactory jsonNodeFactory) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setNodeFactory(jsonNodeFactory);
+        if (configs != null) {
+            if (!CollectionUtils.isEmpty(configs.getJacksonSerializationFeatures())) {
+                configs.getJacksonSerializationFeatures()
+                        .forEach(objectMapper::enable);
+            }
+            if (!CollectionUtils.isEmpty(configs.getJacksonDeserializationFeatures())) {
+                configs.getJacksonDeserializationFeatures()
+                        .forEach(objectMapper::enable);
+            }
+            if (configs.getJavaTimeModuleClass() != null) {
+                objectMapper.registerModule(configs.loadJavaTimeModule());
+                objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+            }
+        }
+
+        return objectMapper;
+    }
+}

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/json/ObjectMapperUtils.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/json/ObjectMapperUtils.java
@@ -22,8 +22,8 @@ public class ObjectMapperUtils {
                         .forEach(objectMapper::enable);
             }
             if (configs.getJavaTimeModuleClass() != null) {
-                objectMapper.registerModule(configs.loadJavaTimeModule());
                 objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+                objectMapper.registerModule(configs.loadJavaTimeModule());
             }
         }
 

--- a/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializerTest.java
+++ b/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializerTest.java
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.services.schemaregistry.deserializers.json;
 
+import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
@@ -26,10 +27,10 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JsonDeserializerTest {
-    private JsonDeserializer defaultJsonDeserializer = new JsonDeserializer(null);
 
     @Test
     public void testDeserialize_nullArgs_throwsException() {
+        JsonDeserializer defaultJsonDeserializer = new JsonDeserializer(new GlueSchemaRegistryConfiguration("us-west-1"));
         String testSchemaDefinition = "{\"$id\":\"https://example.com/geographical-location.schema.json\","
                                       + "\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"title\":\"Longitude "
                                       + "and Latitude Values\",\"description\":\"A geographical coordinate.\","

--- a/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializerTest.java
+++ b/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializerTest.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JsonDeserializerTest {
-    private JsonDeserializer jsonDeserializer = new JsonDeserializer(null);
+    private JsonDeserializer defaultJsonDeserializer = new JsonDeserializer(null);
 
     @Test
     public void testDeserialize_nullArgs_throwsException() {
@@ -42,8 +42,10 @@ public class JsonDeserializerTest {
 
         Schema testSchema = new Schema(testSchemaDefinition, DataFormat.JSON.name(), "testJson");
 
-        assertThrows(IllegalArgumentException.class, () -> jsonDeserializer.deserialize(null, testSchema));
-        assertThrows(IllegalArgumentException.class, () -> jsonDeserializer.deserialize(ByteBuffer.wrap(testBytes),
+        assertThrows(IllegalArgumentException.class, () -> defaultJsonDeserializer.deserialize(null, testSchema));
+        assertThrows(IllegalArgumentException.class, () -> defaultJsonDeserializer.deserialize(ByteBuffer.wrap(testBytes),
                                                                                         null));
     }
+
+
 }

--- a/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/serializers/json/JsonValidatorTest.java
+++ b/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/serializers/json/JsonValidatorTest.java
@@ -13,8 +13,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JsonValidatorTest {
-    private JsonValidator validator = new JsonValidator();
     private ObjectMapper mapper = new ObjectMapper();
+    private JsonValidator validator = new JsonValidator(mapper);
+
     private String stringSchema = "{\n"
             + "  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n"
             + "  \"description\": \"String schema\",\n"

--- a/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/utils/json/ObjectMapperUtilsTest.java
+++ b/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/utils/json/ObjectMapperUtilsTest.java
@@ -1,30 +1,61 @@
 package com.amazonaws.services.schemaregistry.utils.json;
 
 import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
+import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryException;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 
 /**
  * Unit tests for testing object mapper
  */
 public class ObjectMapperUtilsTest {
 
-    static GlueSchemaRegistryConfiguration testConfigs(Map<String, Object> configs) {
-        configs.putIfAbsent(AWSSchemaRegistryConstants.AWS_REGION, "US-West-1");
-        return new GlueSchemaRegistryConfiguration(configs);
+    static GlueSchemaRegistryConfiguration testConfigs(Map<String, Object> map) {
+        return new GlueSchemaRegistryConfiguration(testMap(map));
+    }
+
+    static Map<String, Object> testMap(Map<String, Object> map) {
+        if (map == null) {
+            map = new HashMap<>();
+        }
+        map.putIfAbsent(AWSSchemaRegistryConstants.AWS_REGION, "US-West-1");
+        return map;
     }
 
     @Test
     void testCreate_succeeds() {
-        GlueSchemaRegistryConfiguration cfg = testConfigs(new HashMap<String, Object>());
+        GlueSchemaRegistryConfiguration cfg = testConfigs(null);
 
         ObjectMapper om = ObjectMapperUtils.create(cfg);
+        assertNotNull(om);
+    }
+
+    @Test
+    void testCreate_useJavaTimeModuleWithoutDeps_throwsException() {
+        Map<String, Object> map = testMap(null);
+        map.put(AWSSchemaRegistryConstants.REGISTER_JAVA_TIME_MODULE, "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule");
+        GlueSchemaRegistryConfiguration cfg = testConfigs(map);
+        assertThrows(AWSSchemaRegistryException.class, () -> ObjectMapperUtils.create(cfg));
+    }
+
+    @Test
+    void testCreate_useJavaTimeModuleWithMockTimeModule_succeeds() {
+        Map<String, Object> map = testMap(null);
+        map.put(AWSSchemaRegistryConstants.REGISTER_JAVA_TIME_MODULE, "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule");
+
+        GlueSchemaRegistryConfiguration spy = spy(testConfigs(map));
+        doReturn(new SimpleModule()).when(spy).loadJavaTimeModule();
+
+        ObjectMapper om = ObjectMapperUtils.create(spy);
         assertNotNull(om);
     }
 }

--- a/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/utils/json/ObjectMapperUtilsTest.java
+++ b/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/utils/json/ObjectMapperUtilsTest.java
@@ -1,0 +1,30 @@
+package com.amazonaws.services.schemaregistry.utils.json;
+
+import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
+import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Unit tests for testing object mapper
+ */
+public class ObjectMapperUtilsTest {
+
+    static GlueSchemaRegistryConfiguration testConfigs(Map<String, Object> configs) {
+        configs.putIfAbsent(AWSSchemaRegistryConstants.AWS_REGION, "US-West-1");
+        return new GlueSchemaRegistryConfiguration(configs);
+    }
+
+    @Test
+    void testCreate_succeeds() {
+        GlueSchemaRegistryConfiguration cfg = testConfigs(new HashMap<String, Object>());
+
+        ObjectMapper om = ObjectMapperUtils.create(cfg);
+        assertNotNull(om);
+    }
+}


### PR DESCRIPTION
*Issue:* #202 

*Description of changes:* Configurable support for Java 8 Dates in JSON


Adds support for a [ObjectMapperFactory](https://github.com/amcquistan/aws-glue-schema-registry/blob/json-support-for-java8-datetimes/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/json/ObjectMapperFactory.java) interface and property configuration driven extensibility for JSON support through ObjectMapper with a [DefaultObjectMapperFactory](https://github.com/amcquistan/aws-glue-schema-registry/blob/json-support-for-java8-datetimes/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/json/DefaultObjectMapperFactory.java) implementation

New Configuration Properties: [registerJavaTimeModule and objectMapperFactory](https://github.com/amcquistan/aws-glue-schema-registry/blob/json-support-for-java8-datetimes/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java)

New Constants:  [AwsSchemaRegistryConstants](https://github.com/amcquistan/aws-glue-schema-registry/blob/json-support-for-java8-datetimes/common/src/main/java/com/amazonaws/services/schemaregistry/utils/AWSSchemaRegistryConstants.java)

```
/**
     * Jackson Java Time Module to use for handling Java 8 Date/Time.
     * By default, no module is registered.
     * Ex: com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
     */
    public static final String REGISTER_JAVA_TIME_MODULE = "registerJavaTimeModule";

    /**
     * Factory for creating custom Jackson ObjectMapper instances for use in handling JSON.
     * Default: com.amazonaws.services.schemaregistry.utils.json.DefaultObjectMapperFactory
     */
    public static final String OBJECT_MAPPER_FACTORY = "objectMapperFactory";
```
