### PR TITLE
Bump the AWS SDK version to 2.22.12 and 1.12.633 to fix all vulnerabilities

### DIFF
--- a/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
+++ b/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
@@ -97,6 +97,7 @@ public class GlueSchemaRegistryConfigurationTest {
     public void testBuildConfig_noRegionConfigsSupplied_throwsException() {
         Map<String, Object> configWithoutRegion = new HashMap<>();
         configWithoutRegion.put(AWSSchemaRegistryConstants.AWS_ENDPOINT, "https://test/");
+        System.setProperty("aws.profile", "");
 
         Exception exception = assertThrows(AWSSchemaRegistryException.class,
                 () -> new GlueSchemaRegistryConfiguration(configWithoutRegion));

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -21,3 +21,18 @@ services:
       - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092
       - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092
       - ALLOW_PLAINTEXT_LISTENER=yes
+
+  localstack:
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    image: 'public.ecr.aws/localstack/localstack:latest'
+    ports:
+      - "127.0.0.1:4566:4566"
+    environment:
+      - SERVICES=cloudwatch, dynamodb, kinesis
+      - DEBUG=1
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - DEFAULT_REGION=us-east-2
+      - PARITY_AWS_ACCESS_KEY_ID=1
+    volumes:
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"

--- a/integration-tests/run-local-tests.sh
+++ b/integration-tests/run-local-tests.sh
@@ -115,7 +115,7 @@ cleanUpConnectFiles() {
 
 cleanUpDockerResources || true
 # Start Kafka using docker command asynchronously
-docker-compose up &
+docker-compose up --no-attach localstack &
 sleep 10
 ## Run mvn tests for Kafka and Kinesis Platforms
 cd .. && mvn --file integration-tests/pom.xml verify -Psurefire -X && cd integration-tests
@@ -131,7 +131,7 @@ downloadMongoDBConnector
 copyGSRConverters
 
 runConnectTests() {
-    docker-compose up &
+    docker-compose up --no-attach localstack &
     setUpMongoDBLocal
     startKafkaConnectTasks ${1}
     echo "Waiting for Sink task to pick up data.."

--- a/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kafka/KafkaHelper.java
+++ b/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kafka/KafkaHelper.java
@@ -229,7 +229,7 @@ public class KafkaHelper {
         final KafkaStreams streams = new KafkaStreams(builder.build(), properties);
         streams.cleanUp();
         streams.start();
-        Thread.sleep(1000L);
+        Thread.sleep(5000L);
         streams.close();
 
         log.info("Finish processing {} message streaming via Kafka.", producerProperties.getDataFormat());
@@ -360,9 +360,9 @@ public class KafkaHelper {
 
     private Properties getKafkaStreamsProperties(final ProducerProperties producerProperties) {
         Properties properties = new Properties();
-        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "kafka-streams-test");
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "kafka-streams-test-"+producerProperties.getDataFormat());
         properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapBrokers);
-        properties.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+        properties.put(StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
         properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, GlueSchemaRegistryKafkaStreamsSerde.class);
         properties.put(AWSSchemaRegistryConstants.DATA_FORMAT, producerProperties.getDataFormat());

--- a/pom.xml
+++ b/pom.xml
@@ -80,10 +80,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <glue.schema.registry.groupId>software.amazon.glue</glue.schema.registry.groupId>
-        <aws.sdk.v2.version>2.18.4</aws.sdk.v2.version>
-        <aws.sdk.v1.version>1.12.151</aws.sdk.v1.version>
+        <aws.sdk.v2.version>2.22.12</aws.sdk.v2.version>
+        <aws.sdk.v1.version>1.12.633</aws.sdk.v1.version>
         <kafka.scala.version>2.12</kafka.scala.version>
-        <kafka.version>3.6.0</kafka.version>
+        <kafka.version>3.6.1</kafka.version>
         <avro.version>1.11.3</avro.version>
         <mbknor.jsonschema.converter.version>1.0.39</mbknor.jsonschema.converter.version>
         <everit.json.schema.version>1.14.2</everit.json.schema.version>
@@ -105,16 +105,16 @@
         <hamcrest.version>1.1</hamcrest.version>
         <!--  LATEST KCL Does not work with LocalStack yet, remove once new version works -->
         <kinesis.client.version>2.2.9</kinesis.client.version>
-        <kinesis.producer.version>LATEST</kinesis.producer.version>
+        <!--  LATEST KPL will cause integration test failure in Linux environment, update once we find a way to address the issue -->
+        <kinesis.producer.version>0.15.8</kinesis.producer.version>
         <junit.platform.commons.version>1.6.2</junit.platform.commons.version>
         <junit.platform.surefire.version>1.3.2</junit.platform.surefire.version>
         <guava.version>32.0.0-jre</guava.version>
         <commons.lang3.version>3.8.1</commons.lang3.version>
         <commons.cli.version>1.2</commons.cli.version>
         <awaitility.version>3.0.0</awaitility.version>
-        <localstack.utils>0.2.11</localstack.utils>
         <protobuf.java.version>3.19.6</protobuf.java.version>
-        <localstack.utils>0.2.11</localstack.utils>
+        <localstack.utils>0.2.23</localstack.utils>
         <aws.msk.iam.auth>1.1.5</aws.msk.iam.auth>
     </properties>
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Increasing the AWS SDK version to fix some vulnerabilities we have

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
