### PR TITLE
fix(protobuf): Use the current thread classloader when deserializing …

### DIFF
--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/protobuf/ProtobufWireFormatDecoder.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/protobuf/ProtobufWireFormatDecoder.java
@@ -69,7 +69,7 @@ public class ProtobufWireFormatDecoder {
     private Object deserializeToPojo(final Descriptors.Descriptor descriptor, final CodedInputStream codedInputStream) {
         final String className = ProtobufClassName.from(descriptor);
         try {
-            final Class<?> classType = Class.forName(className);
+            final Class<?> classType = Thread.currentThread().getContextClassLoader().loadClass(className);
             final Method parseMethod = classType.getMethod("parseFrom", CodedInputStream.class);
             return parseMethod.invoke(classType, codedInputStream);
         } catch (Exception e) {


### PR DESCRIPTION
…to pojo.

*Issue #, if available:*

Closes #186

*Description of changes:*
Use the current thread classloader when deserializing protobuf to pojo to add support for layered classloaders, such as what quarkus uses in dev mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
