### PR TITLE
Fix for CVE-2023-5072 with transitive json dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
         <protobuf.java.version>3.19.6</protobuf.java.version>
         <localstack.utils>0.2.23</localstack.utils>
         <aws.msk.iam.auth>2.0.3</aws.msk.iam.auth>
+        <org.json.version>20231013</org.json.version>
     </properties>
 
     <dependencyManagement>
@@ -251,6 +252,13 @@
                 <groupId>com.github.erosb</groupId>
                 <artifactId>everit-json-schema</artifactId>
                 <version>${everit.json.schema.version}</version>
+                <!-- Temporary fix until library is updated -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.json</groupId>
+                        <artifactId>json</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.amazonaws</groupId>
@@ -359,7 +367,7 @@
             <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
-                <version>20231013</version>
+                <version>${org.json.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/serializer-deserializer/pom.xml
+++ b/serializer-deserializer/pom.xml
@@ -104,13 +104,17 @@
         <dependency>
             <groupId>com.github.erosb</groupId>
             <artifactId>everit-json-schema</artifactId>
-            <version>1.14.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-collections</groupId>
                     <artifactId>commons-collections</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Temporary fix until everit-json-schema is updated -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Issue #, if available:
#317 CVE-2023-5072

Description of changes:

Force dependency on latest json version instead of relying on transitive that has an older version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
