### PR TITLE
Bump protobuf version to 3.25.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <jackson.version>2.12.2</jackson.version>
         <!-- Protobuf -->
         <proto-plugin.version>0.6.1</proto-plugin.version>
-	<protobuf.version>3.19.6</protobuf.version>
+	<protobuf.version>3.25.5</protobuf.version>
 	<kotlin.version>1.7.10</kotlin.version>
         <square-wireschema.version>4.3.0</square-wireschema.version>
         <apicurio-registry.version>2.1.3.Final</apicurio-registry.version>
@@ -112,7 +112,7 @@
         <commons.lang3.version>3.8.1</commons.lang3.version>
         <commons.cli.version>1.2</commons.cli.version>
         <awaitility.version>3.0.0</awaitility.version>
-        <protobuf.java.version>3.19.6</protobuf.java.version>
+        <protobuf.java.version>3.25.5</protobuf.java.version>
         <localstack.utils>0.2.23</localstack.utils>
         <aws.msk.iam.auth>2.0.3</aws.msk.iam.auth>
     </properties>


### PR DESCRIPTION
Description of changes:
Bump protobuf version to 3.25.5 to fix vulnerabilities

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
