### PR TITLE
Bump flink version to 1.20.1

### DIFF
--- a/avro-flink-serde/pom.xml
+++ b/avro-flink-serde/pom.xml
@@ -141,7 +141,7 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-avro</artifactId>
-            <version>1.12.2</version>
+            <version>1.20.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>
@@ -152,8 +152,8 @@
 
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-java_2.11</artifactId>
-            <version>1.12.2</version>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>1.20.1</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-glue-schema-registry/issues/371

Since flink 1.19 onwards, there is a change to `getEncorder` method return type in `flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroSerializationSchema.java` in https://github.com/apache/flink/commit/f8da7589223de8fd2a0809595ce33f217de6305f#diff-6da958ea13dc42cb06d10e96c86455ab15a02721d6f5f187cb0ab6f8cf0115dfL110

The return type has changed from `BinaryEncoder` to `Encoder`. 

As software.amazon.glue:schema-registry-flink-serde:1.1.23 is compiled against org.apache.flink:flink-avro:1.12.2, this means that flink 1.19 onwards no longer works with software.amazon.glue:schema-registry-flink-serde:1.1.23 and throws java.lang.NoSuchMethodError exception.


*Description of changes:*

This change bumps the flink dependency version from 1.12.2 to 1.20.1. 

Note that this is a breaking change as older flink version will not work with this new flink-avro version, hence recommend this commit to be included in a new major version release

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
