### PR TITLE
Extend Avro Converter to support Cross-Account schema registry access 

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ repository for the latest support: [Avro SerializationSchema and Deserialization
 
 The `AWSKafkaAvroConverter` Avro converter is able to assume an IAM role in a different AWS account before accessing Glue Schema Registry. You can configure the role ARN and an optional session name.
 
-If `registry.assume.role.arn` is not provided, the converter will fallback to using the default credentials associated to the host.
+If `assumeRoleArn` is not provided, the converter will fallback to using the default credentials associated to the host.
 
 ### Connector configuration
 
@@ -652,12 +652,12 @@ key.converter=com.amazonaws.services.schemaregistry.kafkaconnect.AWSKafkaAvroCon
 value.converter=com.amazonaws.services.schemaregistry.kafkaconnect.AWSKafkaAvroConverter
 
 # Specify cross-account role arn
-key.converter.registry.assume.role.arn="arn:aws:iam::123456789012:role/my-role"
-value.converter.registry.assume.role.arn="arn:aws:iam::123456789012:role/my-role"
+key.converter.assumeRoleArn="arn:aws:iam::123456789012:role/my-role"
+value.converter.assumeRoleArn="arn:aws:iam::123456789012:role/my-role"
 
 # Override default session name (optional; default is "kafka-connect-session")
-key.converter.registry.assume.role.session.name=my-custom-session
-value.converter.registry.assume.role.session.name=my-custom-session
+key.converter.assumeRoleSessionName=my-custom-session
+value.converter.assumeRoleSessionName=my-custom-session
 ```
  
  ## Security issue notifications

--- a/avro-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/AWSKafkaAvroConverter.java
+++ b/avro-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/AWSKafkaAvroConverter.java
@@ -81,10 +81,11 @@ public class AWSKafkaAvroConverter implements Converter {
         this.isKey = isKey;
         new AWSKafkaAvroConverterConfig(configs);
 
+        //TODO: add this feature to all other converters
         String roleToAssume = (String) configs.get(AWSSchemaRegistryConstants.ASSUME_ROLE_ARN);
         if (roleToAssume != null && !roleToAssume.isEmpty()) {
-            String sessionName = configs.get(AWSSchemaRegistryConstants.ASSUME_ROLE_SESSION) != null
-                    ? configs.get(AWSSchemaRegistryConstants.ASSUME_ROLE_SESSION).toString()
+            String sessionName = configs.get(AWSSchemaRegistryConstants.ASSUME_ROLE_SESSION_NAME) != null
+                    ? configs.get(AWSSchemaRegistryConstants.ASSUME_ROLE_SESSION_NAME).toString()
                     : "kafka-connect-session";
 
             String region = configs.get(AWSSchemaRegistryConstants.AWS_REGION).toString();

--- a/avro-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/AWSKafkaAvroConverterTest.java
+++ b/avro-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/AWSKafkaAvroConverterTest.java
@@ -47,7 +47,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants.ASSUME_ROLE_ARN;
-import static com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants.ASSUME_ROLE_SESSION;
+import static com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants.ASSUME_ROLE_SESSION_NAME;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.*;
@@ -166,7 +166,7 @@ public class AWSKafkaAvroConverterTest {
     @Test
     void testConverter_configure_invokeAssumeRoleWithCustomSession() {
         configs.put(ASSUME_ROLE_ARN, ROLE_ARN);
-        configs.put(ASSUME_ROLE_SESSION, "my-session");
+        configs.put(ASSUME_ROLE_SESSION_NAME, "my-session");
 
         converter = spy(new AWSKafkaAvroConverter());
         doReturn(mockCredProvider)

--- a/common/src/main/java/com/amazonaws/services/schemaregistry/utils/AWSSchemaRegistryConstants.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/utils/AWSSchemaRegistryConstants.java
@@ -173,14 +173,14 @@ public final class AWSSchemaRegistryConstants {
     public static final String USER_AGENT_APP = "userAgentApp";
 
     /**
-     * Cross account assume role ARN.
+     * IAM Role ARN to assume for accessing the registry
      */
-    public static final String ASSUME_ROLE_ARN = "registry.assume.role.arn";
+    public static final String ASSUME_ROLE_ARN = "assumeRoleArn";
 
     /**
-     * Cross account assume role session name.
+     * IAM Role session name for accessing the registry
      */
-    public static final String ASSUME_ROLE_SESSION = "registry.assume.role.session.name";
+    public static final String ASSUME_ROLE_SESSION_NAME = "assumeRoleSessionName";
 
     /**
      * Private constructor to avoid initialization of the class.


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/awslabs/aws-glue-schema-registry/issues/252

*Description of changes:*
- Extended `AWSKafkaAvroConverter` in `AWSCrossAccountKafkaAvroConverter`, adding support for cross account schema registry access via assume role.
- Documented how to configure assume.role.arn and optional assume.role.session for both key.converter and value.converter

Motivation: By default, AWSKafkaAvroConverter uses the host’s IAM credentials, requiring custom code to access a Glue Schema Registry in another AWS account. Adding assume.role.arn (and optional assume.role.session) lets the converter assume a cross-account role, eliminating custom boilerplate code and simplifying cross-account schema access.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
