### PR TITLE
Bumped wire schema version to resolve CVE 

### DIFF
--- a/.github/workflows/MavenCI.yml
+++ b/.github/workflows/MavenCI.yml
@@ -30,7 +30,7 @@ jobs:
         java-version: ${{ matrix.java-version }}
 
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,3 +93,6 @@ GlueSchemaRegistryKafkaSerializer/GlueSchemaRegistryKafkaDeserializer.
 
 ## Release 1.1.23
 * Upgraded json-schema dependencies version to fix vulnerabilities
+
+## Release 1.1.24
+* Upgraded square-wireschema version to fix vulnerabilities

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The recommended way to use the AWS Glue Schema Registry Library for Java is to c
   <dependency>
       <groupId>software.amazon.glue</groupId>
       <artifactId>schema-registry-serde</artifactId>
-      <version>1.1.23</version>
+      <version>1.1.24</version>
   </dependency>
   ```
 ### Code Example
@@ -490,7 +490,7 @@ It should look like this
 * If using bash, run the below commands to set-up your CLASSPATH in your bash_profile. (For any other shell, update the environment accordingly.)
   ```bash
       echo 'export GSR_LIB_BASE_DIR=<>' >>~/.bash_profile
-      echo 'export GSR_LIB_VERSION=1.1.23' >>~/.bash_profile
+      echo 'export GSR_LIB_VERSION=1.1.24' >>~/.bash_profile
       echo 'export KAFKA_HOME=<your kafka installation directory>' >>~/.bash_profile
       echo 'export CLASSPATH=$CLASSPATH:$GSR_LIB_BASE_DIR/avro-kafkaconnect-converter/target/schema-registry-kafkaconnect-converter-$GSR_LIB_VERSION.jar:$GSR_LIB_BASE_DIR/common/target/schema-registry-common-$GSR_LIB_VERSION.jar:$GSR_LIB_BASE_DIR/avro-serializer-deserializer/target/schema-registry-serde-$GSR_LIB_VERSION.jar' >>~/.bash_profile
       source ~/.bash_profile
@@ -549,7 +549,7 @@ It should look like this
   <dependency>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-kafkastreams-serde</artifactId>
-        <version>1.1.23</version>
+        <version>1.1.24</version>
   </dependency>
   ```
 
@@ -587,7 +587,7 @@ repository for the latest support: [Avro SerializationSchema and Deserialization
   <dependency>
        <groupId>software.amazon.glue</groupId>
        <artifactId>schema-registry-flink-serde</artifactId>
-       <version>1.1.23</version>
+       <version>1.1.24</version>
   </dependency>
   ```
 ### Code Example

--- a/avro-flink-serde/README.md
+++ b/avro-flink-serde/README.md
@@ -20,7 +20,7 @@ inside Amazon VPC.](https://docs.aws.amazon.com/kinesisanalytics/latest/java/vpc
   <dependency>
        <groupId>software.amazon.glue</groupId>
        <artifactId>schema-registry-flink-serde</artifactId>
-       <version>1.1.23/version>
+       <version>1.1.24/version>
   </dependency>
   ```
 ### Code Example

--- a/avro-flink-serde/pom.xml
+++ b/avro-flink-serde/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>software.amazon.glue</groupId>
     <artifactId>schema-registry-flink-serde</artifactId>
-    <version>1.1.23</version>
+    <version>1.1.24</version>
     <name>AWS Glue Schema Registry Flink Avro Serialization Deserialization Schema</name>
     <description>The AWS Glue Schema Registry Library for Apache Flink enables Java developers to easily integrate
         their Apache Flink applications with AWS Glue Schema Registry
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-serde</artifactId>
-            <version>1.1.23</version>
+            <version>1.1.24</version>
         </dependency>
         <dependency>
           <groupId>org.projectlombok</groupId>

--- a/avro-kafkaconnect-converter/pom.xml
+++ b/avro-kafkaconnect-converter/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.23</version>
+        <version>1.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.23</version>
+        <version>1.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.23</version>
+        <version>1.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.23</version>
+        <version>1.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.23</version>
+        <version>1.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jsonschema-kafkaconnect-converter/pom.xml
+++ b/jsonschema-kafkaconnect-converter/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.23</version>
+        <version>1.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kafkastreams-serde/pom.xml
+++ b/kafkastreams-serde/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.23</version>
+        <version>1.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>software.amazon.glue</groupId>
     <artifactId>schema-registry-parent</artifactId>
-    <version>1.1.23</version>
+    <version>1.1.24</version>
     <packaging>pom</packaging>
     <name>AWS Glue Schema Registry Library</name>
     <description>The AWS Glue Schema Registry Library for Java enables Java developers to easily integrate their

--- a/pom.xml
+++ b/pom.xml
@@ -93,8 +93,8 @@
         <!-- Protobuf -->
         <proto-plugin.version>0.6.1</proto-plugin.version>
 	<protobuf.version>3.25.5</protobuf.version>
-	<kotlin.version>1.7.10</kotlin.version>
-        <square-wireschema.version>4.3.0</square-wireschema.version>
+	<kotlin.version>1.9.25</kotlin.version>
+        <square-wireschema.version>5.2.0</square-wireschema.version>
         <apicurio-registry.version>2.1.3.Final</apicurio-registry.version>
         <slf4j.version>1.7.30</slf4j.version>
         <log4j.version>2.17.1</log4j.version>

--- a/protobuf-kafkaconnect-converter/pom.xml
+++ b/protobuf-kafkaconnect-converter/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.23</version>
+        <version>1.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/serializer-deserializer-msk-iam/pom.xml
+++ b/serializer-deserializer-msk-iam/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.23</version>
+        <version>1.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/serializer-deserializer/pom.xml
+++ b/serializer-deserializer/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.23</version>
+        <version>1.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/apicurio/FileDescriptorUtils.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/apicurio/FileDescriptorUtils.java
@@ -584,7 +584,7 @@ public class FileDescriptorUtils {
      * This method generates the synthetic one-of from a Proto3 optional field.
      */
     private static OneOf getProto3OptionalField(Field field) {
-        return new OneOf("_" + field.getName(), "", Collections.singletonList(field));
+        return new OneOf("_" + field.getName(), "", Collections.singletonList(field), DEFAULT_LOCATION, new Options(Options.FIELD_OPTIONS, Collections.emptyList()));
     }
 
     private static EnumDescriptorProto enumElementToProto(EnumType enumElem) {
@@ -852,7 +852,7 @@ public class FileDescriptorUtils {
             int start = extensionRange.getStart();
             int end = extensionRange.getEnd() - 1;
             values.add(new IntRange(start, end));
-            ExtensionsElement extensionsElement = new ExtensionsElement(DEFAULT_LOCATION, "", values);
+            ExtensionsElement extensionsElement = new ExtensionsElement(DEFAULT_LOCATION, "", values, Collections.emptyList());
             extensions.add(extensionsElement);
         }
         ImmutableList.Builder<OptionElement> options = ImmutableList.builder();
@@ -878,12 +878,13 @@ public class FileDescriptorUtils {
                     .filter(e -> e.getValue().build().size() != 0)
                     .map(e -> toOneof(e.getKey(), e.getValue())).collect(Collectors.toList()),
                 extensions.build(),
+                Collections.emptyList(),
                 Collections.emptyList()
         );
     }
 
     private static OneOfElement toOneof(String name, ImmutableList.Builder<FieldElement> fields) {
-        return new OneOfElement(name, "", fields.build(), Collections.emptyList(), Collections.emptyList());
+        return new OneOfElement(name, "", fields.build(), Collections.emptyList(), Collections.emptyList(), DEFAULT_LOCATION);
     }
 
     private static EnumElement toEnum(EnumDescriptorProto ed) {


### PR DESCRIPTION
*Issue #, if available:*
wire schema version had a CVE in the dependency chain. Bumped wire schema version and made changes to usage to support new version.
*Description of changes:*
Bumped wire.schema version to version without CVE.
Changed constructors utilized within FileDescriptor utlis.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
