### PR TITLE
Add Protobuf serializer and deserializer for KafkaFlow integration + Update CMAKEs for easier dll disovery

### DIFF
--- a/native-schema-registry/c/CMakeLists.txt
+++ b/native-schema-registry/c/CMakeLists.txt
@@ -20,20 +20,21 @@ ELSEIF(APPLE)
 ELSE()
     set(LIB_NATIVE_SCHEMA_REGISTRY_LIBRARY_NAME ${LIB_NATIVE_SCHEMA_REGISTRY_LIBRARY_NAME_PREFIX}.so)
 ENDIF()
-
 set(DATA_TYPES_MODULE_NAME native_schema_registry_c_data_types)
 set(SERDE_MODULE_NAME native_schema_registry_c)
 set(AWS_COMMON_MEMALLOC aws_common_memalloc)
 set(NATIVE_SCHEMA_REGISTRY_MODULE_NAME libnativeschemaregistry)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
+##Global RPATH Configuration for Portable Libraries
+set(CMAKE_SKIP_BUILD_RPATH FALSE)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+set(CMAKE_INSTALL_RPATH "$ORIGIN")
+
 include_directories("include")
 include_directories(${LIB_NATIVE_SCHEMA_REGISTRY_PATH})
-
-find_package(Python3 REQUIRED COMPONENTS Development)
-
-include_directories(${Python3_INCLUDE_DIRS})
-link_libraries(${Python3_LIBRARIES})
+# --- Python Integration ---
 
 add_subdirectory("src")
 include (CTest)

--- a/native-schema-registry/c/src/CMakeLists.txt
+++ b/native-schema-registry/c/src/CMakeLists.txt
@@ -5,9 +5,14 @@ if (CMAKE_SYSTEM_NAME MATCHES "^(Linux)$")
         list(APPEND TEST_COVERAGE "-ftest-coverage -fprofile-arcs")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${TEST_COVERAGE} -g -O0 -Wall")
         set(CMAKE_C_CLANG_TIDY clang-tidy -checks=-*,readability-*)
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lgcov")
 endif()
 
 add_library(${AWS_COMMON_MEMALLOC} SHARED memory_allocator.c)
+set_target_properties(${AWS_COMMON_MEMALLOC} PROPERTIES
+    BUILD_RPATH "$ORIGIN"
+    INSTALL_RPATH "$ORIGIN"
+)
 target_link_libraries(${AWS_COMMON_MEMALLOC} PRIVATE ${AWS_C_COMMON})
 
 #Adding modules in the build order.
@@ -17,6 +22,10 @@ add_library(
         read_only_byte_array.c
         mutable_byte_array.c
         glue_schema_registry_error.c
+)
+set_target_properties(${DATA_TYPES_MODULE_NAME} PROPERTIES
+    BUILD_RPATH "$ORIGIN"
+    INSTALL_RPATH "$ORIGIN"
 )
 add_custom_command(
         TARGET ${DATA_TYPES_MODULE_NAME}
@@ -38,12 +47,17 @@ set_target_properties(
         IMPORTED_LOCATION "${LIB_NATIVE_SCHEMA_REGISTRY_PATH}/${LIB_NATIVE_SCHEMA_REGISTRY_LIBRARY_NAME}"
         IMPORTED_IMPLIB "${LIB_NATIVE_SCHEMA_REGISTRY_PATH}/${LIB_NATIVE_SCHEMA_REGISTRY_LIBRARY_OBJ_NAME}"
         INTERFACE_INCLUDE_DIRECTORIES "${LIB_NATIVE_SCHEMA_REGISTRY_PATH}"
+        IMPORTED_NO_SONAME TRUE
 )
 
 add_library(
         ${SERDE_MODULE_NAME} SHARED
         glue_schema_registry_serializer.c
         glue_schema_registry_deserializer.c
+)
+set_target_properties(${SERDE_MODULE_NAME} PROPERTIES
+    BUILD_RPATH "$ORIGIN"
+    INSTALL_RPATH "$ORIGIN"
 )
 
 target_link_libraries(
@@ -88,7 +102,10 @@ set_target_properties(
         PROPERTIES
         INCLUDE_DIRECTORIES "${PROJECT_SOURCE_DIR}/include/"
         SWIG_USE_TARGET_INCLUDE_DIRECTORIES TRUE
+        BUILD_RPATH "$ORIGIN"
+        INSTALL_RPATH "$ORIGIN"
 )
+
 swig_link_libraries(
         ${CSHARP_MODULE_NAME}
         PUBLIC
@@ -109,38 +126,48 @@ add_custom_command(
         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${SERDE_MODULE_NAME}> ${CSHARP_GEN_LIB_PATH}/
 )
 
-####Python
-find_package(PythonLibs REQUIRED)
-set(PYTHON_MODULE_NAME GsrSerDePyGen)
-set(PYTHON_ROOT_PATH ${PROJECT_SOURCE_DIR}/../python/PyGsrSerDe)
-set(PYTHON_SOURCE_PATH ${PYTHON_ROOT_PATH}/)
-set(PYTHON_GEN_LIB_PATH ${PYTHON_ROOT_PATH})
-swig_add_library(
-        ${PYTHON_MODULE_NAME}
-        TYPE SHARED
-        LANGUAGE python
-        OUTPUT_DIR "${PYTHON_SOURCE_PATH}"
-        SOURCES ${GsrSerDeSrc}
-)
-list(APPEND PYTHON_INCLUDES
-        "${PROJECT_SOURCE_DIR}/include/"
-        #TODO: Path needs to be configurable per version and OS
-        "/usr/include/python3.7m/")
+####Go 
+#set(GO_MODULE_NAME GsrSerDeGoGen)
+#set(GO_ROOT_PATH ${PROJECT_SOURCE_DIR}/../golang)
+#set(GO_SOURCE_PATH ${GO_ROOT_PATH}/pkg/GsrSerDe)
+#set(GO_LIB_PATH ${GO_ROOT_PATH}/lib)
+#swig_add_library(
+#        ${GO_MODULE_NAME}
+#        TYPE SHARED
+#        LANGUAGE go
+#        OUTPUT_DIR "${GO_SOURCE_PATH}"
+#        SOURCES ${GsrSerDeSrc}
+#)
+#set_target_properties(
+#        ${GO_MODULE_NAME}
+#        PROPERTIES
+#        INCLUDE_DIRECTORIES "${PROJECT_SOURCE_DIR}/include/"
+#        SWIG_USE_TARGET_INCLUDE_DIRECTORIES TRUE
+#        BUILD_RPATH "$ORIGIN"
+#        INSTALL_RPATH "$ORIGIN"
+#)
+#swig_link_libraries(
+#        ${GO_MODULE_NAME}
+#        PUBLIC
+#        ${DATA_TYPES_MODULE_NAME}
+#        ${SERDE_MODULE_NAME}
+#        ${AWS_COMMON_MEMALLOC}
+#        ${NATIVE_SCHEMA_REGISTRY_MODULE_NAME}
+#)
+## Copy shared libraries to lib directory
+#add_custom_command(
+#        TARGET ${GO_MODULE_NAME}
+#        POST_BUILD
+#        COMMAND ${CMAKE_COMMAND} -E make_directory ${GO_LIB_PATH}
+#        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${DATA_TYPES_MODULE_NAME}> ${GO_LIB_PATH}/
+#        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${NATIVE_SCHEMA_REGISTRY_MODULE_NAME}> ${GO_LIB_PATH}/
+#        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${AWS_COMMON_MEMALLOC}> ${GO_LIB_PATH}/
+#        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${SERDE_MODULE_NAME}> ${GO_LIB_PATH}/
+#        COMMAND ${CMAKE_COMMAND} -E make_directory ${GO_LIB_PATH}/include
+#        COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/include/ ${GO_LIB_PATH}/include/
+#)
 
-target_include_directories(${PYTHON_MODULE_NAME} PUBLIC ${PYTHON_INCLUDES})
-set_target_properties(
-        ${PYTHON_MODULE_NAME}
-        PROPERTIES
-        SWIG_USE_TARGET_INCLUDE_DIRECTORIES TRUE
-)
-
-##TODO: Fix this during release. We should segregate Debug and Release
-##Copying built libraries to PYTHON project
-add_custom_command(
-        TARGET ${PYTHON_MODULE_NAME}
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${DATA_TYPES_MODULE_NAME}> ${PYTHON_GEN_LIB_PATH}/
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${NATIVE_SCHEMA_REGISTRY_MODULE_NAME}> ${PYTHON_GEN_LIB_PATH}/
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${AWS_COMMON_MEMALLOC}> ${PYTHON_GEN_LIB_PATH}/
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${SERDE_MODULE_NAME}> ${PYTHON_GEN_LIB_PATH}/
-)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU")
+    add_compile_options(--coverage)
+    link_libraries(gcov)
+endif()

--- a/native-schema-registry/c/src/CMakeLists.txt
+++ b/native-schema-registry/c/src/CMakeLists.txt
@@ -126,47 +126,6 @@ add_custom_command(
         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${SERDE_MODULE_NAME}> ${CSHARP_GEN_LIB_PATH}/
 )
 
-####Go 
-#set(GO_MODULE_NAME GsrSerDeGoGen)
-#set(GO_ROOT_PATH ${PROJECT_SOURCE_DIR}/../golang)
-#set(GO_SOURCE_PATH ${GO_ROOT_PATH}/pkg/GsrSerDe)
-#set(GO_LIB_PATH ${GO_ROOT_PATH}/lib)
-#swig_add_library(
-#        ${GO_MODULE_NAME}
-#        TYPE SHARED
-#        LANGUAGE go
-#        OUTPUT_DIR "${GO_SOURCE_PATH}"
-#        SOURCES ${GsrSerDeSrc}
-#)
-#set_target_properties(
-#        ${GO_MODULE_NAME}
-#        PROPERTIES
-#        INCLUDE_DIRECTORIES "${PROJECT_SOURCE_DIR}/include/"
-#        SWIG_USE_TARGET_INCLUDE_DIRECTORIES TRUE
-#        BUILD_RPATH "$ORIGIN"
-#        INSTALL_RPATH "$ORIGIN"
-#)
-#swig_link_libraries(
-#        ${GO_MODULE_NAME}
-#        PUBLIC
-#        ${DATA_TYPES_MODULE_NAME}
-#        ${SERDE_MODULE_NAME}
-#        ${AWS_COMMON_MEMALLOC}
-#        ${NATIVE_SCHEMA_REGISTRY_MODULE_NAME}
-#)
-## Copy shared libraries to lib directory
-#add_custom_command(
-#        TARGET ${GO_MODULE_NAME}
-#        POST_BUILD
-#        COMMAND ${CMAKE_COMMAND} -E make_directory ${GO_LIB_PATH}
-#        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${DATA_TYPES_MODULE_NAME}> ${GO_LIB_PATH}/
-#        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${NATIVE_SCHEMA_REGISTRY_MODULE_NAME}> ${GO_LIB_PATH}/
-#        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${AWS_COMMON_MEMALLOC}> ${GO_LIB_PATH}/
-#        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${SERDE_MODULE_NAME}> ${GO_LIB_PATH}/
-#        COMMAND ${CMAKE_COMMAND} -E make_directory ${GO_LIB_PATH}/include
-#        COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/include/ ${GO_LIB_PATH}/include/
-#)
-
 if(CMAKE_C_COMPILER_ID MATCHES "GNU")
     add_compile_options(--coverage)
     link_libraries(gcov)

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/AWSGsrSerDe.Tests.csproj
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/AWSGsrSerDe.Tests.csproj
@@ -13,6 +13,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="KafkaFlow" Version="3.0.10" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
         <PackageReference Include="NJsonSchema" Version="10.8.0" />
         <PackageReference Include="NUnit" Version="3.12.0" />

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufDeserializerTests.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufDeserializerTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using AWSGsrSerDe.KafkaFlow;
+using Com.Amazonaws.Services.Schemaregistry.Tests.Protobuf.Syntax2;
+using KafkaFlow;
+using NUnit.Framework;
+
+namespace AWSGsrSerDe.Tests.KafkaFlow
+{
+    [TestFixture]
+    public class GlueSchemaRegistryKafkaFlowProtobufDeserializerTests
+    {
+        private const string ValidConfigPath = "deserializer-test-config.properties";
+        
+        [SetUp]
+        public void Setup()
+        {
+            // Create a minimal config file for testing
+            var configContent = @"region=us-east-1
+                registry.name=default-registry
+                dataFormat=PROTOBUF
+                schemaAutoRegistrationEnabled=true";
+            
+            if (File.Exists(ValidConfigPath))
+            {
+                File.Delete(ValidConfigPath);
+            }
+            File.WriteAllText(ValidConfigPath, configContent);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (File.Exists(ValidConfigPath))
+            {
+                File.Delete(ValidConfigPath);
+            }
+        }
+
+        [Test]
+        public void Deserialize_WithValidSerializedData_ReturnsOriginalData()
+        {
+            // Arrange
+            var originalCustomer = new Customer { Name = "John Doe" };
+            var context = new TestDeserializerContext("deserializer-test-topic");
+            
+            var serializer = new GsrKafkaFlowProtobufSerializer<Customer>(ValidConfigPath);
+            var deserializer = new GsrKafkaFlowProtobufDeserializer<Customer>(ValidConfigPath);
+
+            // First serialize the data
+            var serializedData = serializer.Serialize(originalCustomer, context);
+            
+            // Act - Deserialize
+            var deserializedCustomer = (Customer)deserializer.Deserialize(serializedData, typeof(Customer), context);
+
+            // Assert
+            Assert.IsNotNull(deserializedCustomer);
+            Assert.AreEqual(originalCustomer.Name, deserializedCustomer.Name);
+            Assert.AreEqual(originalCustomer.HasName, deserializedCustomer.HasName);
+            Assert.AreEqual(originalCustomer, deserializedCustomer);
+        }
+
+        [Test]
+        public async Task DeserializeAsync_WithValidSerializedData_ReturnsOriginalData()
+        {
+            // Arrange
+            var originalAddress = new Address 
+            { 
+                Street = "123 Main St",
+                City = "Test City", 
+                Zip = 12345 
+            };
+            var context = new TestDeserializerContext("deserializer-async-test-topic");
+            
+            var serializer = new GsrKafkaFlowProtobufSerializer<Address>(ValidConfigPath);
+            var deserializer = new GsrKafkaFlowProtobufDeserializer<Address>(ValidConfigPath);
+            using var stream = new MemoryStream();
+
+            // First serialize the data to stream
+            await serializer.SerializeAsync(originalAddress, stream, context);
+            
+            // Reset stream position for reading
+            stream.Position = 0;
+            
+            // Act - Deserialize from stream
+            var deserializedAddress = (Address)await deserializer.DeserializeAsync(stream, typeof(Address), context);
+
+            // Assert
+            Assert.IsNotNull(deserializedAddress);
+            Assert.AreEqual(originalAddress.Street, deserializedAddress.Street);
+            Assert.AreEqual(originalAddress.City, deserializedAddress.City);
+            Assert.AreEqual(originalAddress.Zip, deserializedAddress.Zip);
+            Assert.AreEqual(originalAddress, deserializedAddress);
+        }
+    }
+
+    /// <summary>
+    /// Test implementation of ISerializerContext for testing purposes
+    /// </summary>
+    public class TestDeserializerContext : ISerializerContext
+    {
+        public TestDeserializerContext(string topic)
+        {
+            Topic = topic;
+        }
+
+        public string Topic { get; }
+    }
+}

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufDeserializerTests.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufDeserializerTests.cs
@@ -6,7 +6,7 @@ using Com.Amazonaws.Services.Schemaregistry.Tests.Protobuf.Syntax2;
 using KafkaFlow;
 using NUnit.Framework;
 
-namespace AWSGsrSerDe.Tests.KafkaFlow
+namespace AWSGlueSchemaRegistrySerDe.Tests.KafkaFlow
 {
     [TestFixture]
     public class GlueSchemaRegistryKafkaFlowProtobufDeserializerTests
@@ -45,8 +45,8 @@ namespace AWSGsrSerDe.Tests.KafkaFlow
             var originalCustomer = new Customer { Name = "John Doe" };
             var context = new TestDeserializerContext("deserializer-test-topic");
             
-            var serializer = new GsrKafkaFlowProtobufSerializer<Customer>(ValidConfigPath);
-            var deserializer = new GsrKafkaFlowProtobufDeserializer<Customer>(ValidConfigPath);
+            var serializer = new GlueSchemaRegistryKafkaFlowProtobufSerializer<Customer>(ValidConfigPath);
+            var deserializer = new GlueSchemaRegistryKafkaFlowProtobufDeserializer<Customer>(ValidConfigPath);
 
             // First serialize the data
             var serializedData = serializer.Serialize(originalCustomer, context);
@@ -73,8 +73,8 @@ namespace AWSGsrSerDe.Tests.KafkaFlow
             };
             var context = new TestDeserializerContext("deserializer-async-test-topic");
             
-            var serializer = new GsrKafkaFlowProtobufSerializer<Address>(ValidConfigPath);
-            var deserializer = new GsrKafkaFlowProtobufDeserializer<Address>(ValidConfigPath);
+            var serializer = new GlueSchemaRegistryKafkaFlowProtobufSerializer<Address>(ValidConfigPath);
+            var deserializer = new GlueSchemaRegistryKafkaFlowProtobufDeserializer<Address>(ValidConfigPath);
             using var stream = new MemoryStream();
 
             // First serialize the data to stream

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufSerializerTests.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufSerializerTests.cs
@@ -6,7 +6,7 @@ using Com.Amazonaws.Services.Schemaregistry.Tests.Protobuf.Syntax2;
 using KafkaFlow;
 using NUnit.Framework;
 
-namespace AWSGlueSchemaRegistrySerDe.Tests.KafkaFlow
+namespace AWSGsrSerDe.Tests.KafkaFlow
 {
     [TestFixture]
     public class GlueSchemaRegistryKafkaFlowProtobufSerializerTests

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufSerializerTests.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufSerializerTests.cs
@@ -1,0 +1,145 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using AWSGsrSerDe.KafkaFlow;
+using Com.Amazonaws.Services.Schemaregistry.Tests.Protobuf.Syntax2;
+using KafkaFlow;
+using NUnit.Framework;
+
+namespace AWSGsrSerDe.Tests.KafkaFlow
+{
+    [TestFixture]
+    public class GlueSchemaRegistryKafkaFlowProtobufSerializerTests
+    {
+        private const string ValidConfigPath = "test-config.properties";
+
+        [SetUp]
+        public void Setup()
+        {
+            // Create a minimal config file for testing
+            var configContent = @"region=us-east-1
+                registry.name=test-registry
+                dataFormat=PROTOBUF
+                schemaAutoRegistrationEnabled=true";
+            if (File.Exists(ValidConfigPath))
+            {
+                File.Delete(ValidConfigPath);
+            }
+            File.WriteAllText(ValidConfigPath, configContent);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (File.Exists(ValidConfigPath))
+            {
+                File.Delete(ValidConfigPath);
+            }
+        }
+
+        [Test]
+        public void SerializeDeserialize_Roundtrip_PreservesData()
+        {
+            // Arrange
+            var originalCustomer = new Customer { Name = "John Doe" };
+            var context = new TestSerializerContext("test-topic-kafka-flow");
+
+            var serializer = new GsrKafkaFlowProtobufSerializer<Customer>(ValidConfigPath);
+            var deserializer = new GsrKafkaFlowProtobufDeserializer<Customer>(ValidConfigPath);
+
+            // Act - Serialize
+            var serializedData = serializer.Serialize(originalCustomer, context);
+
+            // Act - Deserialize
+            var deserializedCustomer = (Customer)deserializer.Deserialize(serializedData, typeof(Customer), context);
+
+            // Assert
+            Assert.IsNotNull(deserializedCustomer);
+            Assert.AreEqual(originalCustomer.Name, deserializedCustomer.Name);
+            Assert.AreEqual(originalCustomer.HasName, deserializedCustomer.HasName);
+
+        }
+
+        [Test]
+        public async Task SerializeDeserializeAsync_Roundtrip_PreservesData()
+        {
+            // Arrange
+            var originalCustomer = new Customer { Name = "Jane Smith" };
+            var context = new TestSerializerContext("async-test-topic-kafka-flow");
+
+            var serializer = new GsrKafkaFlowProtobufSerializer<Customer>(ValidConfigPath);
+            var deserializer = new GsrKafkaFlowProtobufDeserializer<Customer>(ValidConfigPath);
+            using var stream = new MemoryStream();
+
+            // Act - Serialize to stream
+            await serializer.SerializeAsync(originalCustomer, stream, context);
+
+            // Reset stream position for reading
+            stream.Position = 0;
+
+            // Act - Deserialize from stream
+            var deserializedCustomer = (Customer)await deserializer.DeserializeAsync(stream, typeof(Customer), context);
+
+            // Assert
+            Assert.IsNotNull(deserializedCustomer);
+            Assert.AreEqual(originalCustomer.Name, deserializedCustomer.Name);
+            Assert.AreEqual(originalCustomer.HasName, deserializedCustomer.HasName);
+        }
+
+        [Test]
+        public void Constructor_WithInvalidConfigPath_ThrowsException()
+        {
+            // Arrange
+            var invalidConfigPath = "non-existent-config.properties";
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                new GsrKafkaFlowProtobufSerializer<Customer>(invalidConfigPath));
+
+            Assert.That(exception.Message, Does.Contain("Failed to initialize GSR KafkaFlow serializer"));
+        }
+
+        [Test]
+        public void Serialize_WithNullMessage_ThrowsException()
+        {
+            // Arrange
+            var serializer = new GsrKafkaFlowProtobufSerializer<Customer>(ValidConfigPath);
+            var context = new TestSerializerContext("test-topic-kf-seriailizer");
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+                serializer.Serialize(null, context));
+
+            Assert.That(exception.ParamName, Is.EqualTo("message"));
+        }
+
+        [Test]
+        public void Serialize_WithNullContext_ThrowsException()
+        {
+            // Arrange
+            var customer = new Customer { Name = "Test Customer" };
+            var serializer = new GsrKafkaFlowProtobufSerializer<Customer>(ValidConfigPath);
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+                serializer.Serialize(customer, null));
+
+            Assert.That(exception.ParamName, Is.EqualTo("context"));
+        }
+        
+        // TODO: Add async tests for SerializeAsync methods
+    }
+
+    /// <summary>
+    /// Test implementation of ISerializerContext for testing purposes
+    /// </summary>
+    public class TestSerializerContext : ISerializerContext
+    {
+        public TestSerializerContext(string topic)
+        {
+            Topic = topic;
+        }
+
+        public string Topic { get; }
+    }
+}

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufSerializerTests.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufSerializerTests.cs
@@ -6,7 +6,7 @@ using Com.Amazonaws.Services.Schemaregistry.Tests.Protobuf.Syntax2;
 using KafkaFlow;
 using NUnit.Framework;
 
-namespace AWSGsrSerDe.Tests.KafkaFlow
+namespace AWSGlueSchemaRegistrySerDe.Tests.KafkaFlow
 {
     [TestFixture]
     public class GlueSchemaRegistryKafkaFlowProtobufSerializerTests
@@ -44,8 +44,8 @@ namespace AWSGsrSerDe.Tests.KafkaFlow
             var originalCustomer = new Customer { Name = "John Doe" };
             var context = new TestSerializerContext("test-topic-kafka-flow");
 
-            var serializer = new GsrKafkaFlowProtobufSerializer<Customer>(ValidConfigPath);
-            var deserializer = new GsrKafkaFlowProtobufDeserializer<Customer>(ValidConfigPath);
+            var serializer = new GlueSchemaRegistryKafkaFlowProtobufSerializer<Customer>(ValidConfigPath);
+            var deserializer = new GlueSchemaRegistryKafkaFlowProtobufDeserializer<Customer>(ValidConfigPath);
 
             // Act - Serialize
             var serializedData = serializer.Serialize(originalCustomer, context);
@@ -67,8 +67,8 @@ namespace AWSGsrSerDe.Tests.KafkaFlow
             var originalCustomer = new Customer { Name = "Jane Smith" };
             var context = new TestSerializerContext("async-test-topic-kafka-flow");
 
-            var serializer = new GsrKafkaFlowProtobufSerializer<Customer>(ValidConfigPath);
-            var deserializer = new GsrKafkaFlowProtobufDeserializer<Customer>(ValidConfigPath);
+            var serializer = new GlueSchemaRegistryKafkaFlowProtobufSerializer<Customer>(ValidConfigPath);
+            var deserializer = new GlueSchemaRegistryKafkaFlowProtobufDeserializer<Customer>(ValidConfigPath);
             using var stream = new MemoryStream();
 
             // Act - Serialize to stream
@@ -94,16 +94,16 @@ namespace AWSGsrSerDe.Tests.KafkaFlow
 
             // Act & Assert
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                new GsrKafkaFlowProtobufSerializer<Customer>(invalidConfigPath));
+                new GlueSchemaRegistryKafkaFlowProtobufSerializer<Customer>(invalidConfigPath));
 
-            Assert.That(exception.Message, Does.Contain("Failed to initialize GSR KafkaFlow serializer"));
+            Assert.That(exception.Message, Does.Contain("Failed to initialize GlueSchemaRegistry KafkaFlow serializer"));
         }
 
         [Test]
         public void Serialize_WithNullMessage_ThrowsException()
         {
             // Arrange
-            var serializer = new GsrKafkaFlowProtobufSerializer<Customer>(ValidConfigPath);
+            var serializer = new GlueSchemaRegistryKafkaFlowProtobufSerializer<Customer>(ValidConfigPath);
             var context = new TestSerializerContext("test-topic-kf-seriailizer");
 
             // Act & Assert
@@ -118,7 +118,7 @@ namespace AWSGsrSerDe.Tests.KafkaFlow
         {
             // Arrange
             var customer = new Customer { Name = "Test Customer" };
-            var serializer = new GsrKafkaFlowProtobufSerializer<Customer>(ValidConfigPath);
+            var serializer = new GlueSchemaRegistryKafkaFlowProtobufSerializer<Customer>(ValidConfigPath);
 
             // Act & Assert
             var exception = Assert.Throws<ArgumentNullException>(() =>

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufSerializerTests.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufSerializerTests.cs
@@ -127,7 +127,7 @@ namespace AWSGlueSchemaRegistrySerDe.Tests.KafkaFlow
             Assert.That(exception.ParamName, Is.EqualTo("context"));
         }
         
-        // TODO: Add async tests for SerializeAsync methods
+        // TODO: Add SerializeAsync failure tests for  methods
     }
 
     /// <summary>

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/AWSGsrSerDe.csproj
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/AWSGsrSerDe.csproj
@@ -12,6 +12,7 @@
     <ItemGroup>
       <PackageReference Include="Apache.Avro" Version="1.11.0" />
       <PackageReference Include="Google.Protobuf" Version="3.21.4" />
+      <PackageReference Include="KafkaFlow" Version="3.0.10" />
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
       <PackageReference Include="NJsonSchema" Version="10.8.0" />
       <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufDeserializer.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufDeserializer.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using AWSGsrSerDe.deserializer;
+using AWSGsrSerDe.common;
+using Google.Protobuf;
+using KafkaFlow;
+
+namespace AWSGsrSerDe.KafkaFlow;
+
+public class GsrKafkaFlowProtobufDeserializer<T> : IDeserializer
+    where T : class, IMessage<T>, new()
+{
+    private readonly GlueSchemaRegistryKafkaDeserializer _gsrDeserializer;
+
+    public GsrKafkaFlowProtobufDeserializer(string configPath)
+    {
+        try
+        {
+            var dataConfig = new GlueSchemaRegistryDataFormatConfiguration(new Dictionary<string, dynamic>
+            {
+                { GlueSchemaRegistryConstants.ProtobufMessageDescriptor, new T().Descriptor }
+            });
+
+            _gsrDeserializer = new GlueSchemaRegistryKafkaDeserializer(configPath, dataConfig);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to initialize GSR KafkaFlow deserializer for {typeof(T).Name}: {ex.Message}", ex);
+        }
+    }
+
+    public object Deserialize(ReadOnlySpan<byte> data, Type type, ISerializerContext context)
+    {
+        try
+        {
+            return _gsrDeserializer.Deserialize(context.Topic, data.ToArray());
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to deserialize {typeof(T).Name} from topic {context.Topic}: {ex.Message}", ex);
+        }
+    }
+
+    public async Task<object> DeserializeAsync(Stream input, Type type, ISerializerContext context)
+    {
+        var data = new byte[input.Length];
+        await input.ReadAsync(data);
+        return Deserialize(data, type, context);
+    }
+
+    // Dispose method is not needed as .NET GC will clean this object and the underlying GlueSchemaRegistryKafkaDeserializer does not implement IDisposable.
+    // If it did, we would implement IDisposable and call Dispose on the deserializer in the Dispose method.
+}

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufDeserializer.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufDeserializer.cs
@@ -33,6 +33,9 @@ public class GlueSchemaRegistryKafkaFlowProtobufDeserializer<T> : IDeserializer
 
     public object Deserialize(ReadOnlySpan<byte> data, Type type, ISerializerContext context)
     {
+        if (context == null)
+            throw new ArgumentNullException(nameof(context));
+
         try
         {
             return _gsrDeserializer.Deserialize(context.Topic, data.ToArray());
@@ -45,6 +48,11 @@ public class GlueSchemaRegistryKafkaFlowProtobufDeserializer<T> : IDeserializer
 
     public async Task<object> DeserializeAsync(Stream input, Type type, ISerializerContext context)
     {
+        if (input == null)
+            throw new ArgumentNullException(nameof(input));
+        if (context == null)
+            throw new ArgumentNullException(nameof(context));
+
         var data = new byte[input.Length];
         await input.ReadAsync(data);
         return Deserialize(data, type, context);

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufDeserializer.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufDeserializer.cs
@@ -9,12 +9,12 @@ using KafkaFlow;
 
 namespace AWSGsrSerDe.KafkaFlow;
 
-public class GsrKafkaFlowProtobufDeserializer<T> : IDeserializer
+public class GlueSchemaRegistryKafkaFlowProtobufDeserializer<T> : IDeserializer
     where T : class, IMessage<T>, new()
 {
     private readonly GlueSchemaRegistryKafkaDeserializer _gsrDeserializer;
 
-    public GsrKafkaFlowProtobufDeserializer(string configPath)
+    public GlueSchemaRegistryKafkaFlowProtobufDeserializer(string configPath)
     {
         try
         {

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufSerializer.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufSerializer.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using AWSGsrSerDe.serializer;
+using AWSGsrSerDe.common;
+using Google.Protobuf;
+using KafkaFlow;
+
+namespace AWSGsrSerDe.KafkaFlow;
+
+public class GsrKafkaFlowProtobufSerializer<T> : ISerializer
+    where T : class, IMessage<T>, new()
+{
+    private readonly GlueSchemaRegistryKafkaSerializer _gsrSerializer;
+
+    public GsrKafkaFlowProtobufSerializer(string configPath)
+    {
+        try
+        {
+            _gsrSerializer = new GlueSchemaRegistryKafkaSerializer(configPath);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to initialize GSR KafkaFlow serializer for {typeof(T).Name}: {ex.Message}", ex);
+        }
+    }
+
+    public byte[] Serialize(object message, ISerializerContext context)
+    {
+        if (message == null)
+            throw new ArgumentNullException(nameof(message));
+        if (context == null)
+            throw new ArgumentNullException(nameof(context));
+
+        try
+        {
+            return _gsrSerializer.Serialize(message, context.Topic);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to serialize {typeof(T).Name} to topic {context.Topic}: {ex.Message}", ex);
+        }
+    }
+
+    public async Task SerializeAsync(object message, Stream output, ISerializerContext context)
+    {
+        if (message == null)
+            throw new ArgumentNullException(nameof(message));
+        if (output == null)
+            throw new ArgumentNullException(nameof(output));
+        if (context == null)
+            throw new ArgumentNullException(nameof(context));
+
+        var data = Serialize(message, context);
+        await output.WriteAsync(data);
+    }
+
+    // Dispose method is not needed as .NET GC will clean this object and the underlying GlueSchemaRegistryKafkaSerializer does not implement IDisposable.
+    // If it did, we would implement IDisposable and call Dispose on the serializer in the Dispose
+
+}

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufSerializer.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/KafkaFlow/GlueSchemaRegistryKafkaFlowProtobufSerializer.cs
@@ -8,12 +8,12 @@ using KafkaFlow;
 
 namespace AWSGsrSerDe.KafkaFlow;
 
-public class GsrKafkaFlowProtobufSerializer<T> : ISerializer
+public class GlueSchemaRegistryKafkaFlowProtobufSerializer<T> : ISerializer
     where T : class, IMessage<T>, new()
 {
     private readonly GlueSchemaRegistryKafkaSerializer _gsrSerializer;
 
-    public GsrKafkaFlowProtobufSerializer(string configPath)
+    public GlueSchemaRegistryKafkaFlowProtobufSerializer(string configPath)
     {
         try
         {

--- a/native-schema-registry/csharp/AWSGsrSerDe/Libs/Libs.projitems
+++ b/native-schema-registry/csharp/AWSGsrSerDe/Libs/Libs.projitems
@@ -15,13 +15,13 @@
     <Content Include="$(MSBuildThisFileDirectory)libnativeschemaregistry.*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)native_schema_registry_c.*">
+    <Content Include="$(MSBuildThisFileDirectory)libnative_schema_registry_c.*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)native_schema_registry_c_data_types.*">
+    <Content Include="$(MSBuildThisFileDirectory)libnative_schema_registry_c_data_types.*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="$(MSBuildThisFileDirectory)aws_common_memalloc.*">
+    <Content Include="$(MSBuildThisFileDirectory)libaws_common_memalloc.*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/native-schema-registry/csharp/AWSGsrSerDe/README.md
+++ b/native-schema-registry/csharp/AWSGsrSerDe/README.md
@@ -14,7 +14,7 @@ Follow the instructions in those specific projects to build them.
 
 ```
 dotnet clean .
-dotnet build .
+dotnet build . --configuration Release
 dotnet test .
 ```
 

--- a/native-schema-registry/csharp/AWSGsrSerDe/README.md
+++ b/native-schema-registry/csharp/AWSGsrSerDe/README.md
@@ -20,7 +20,7 @@ dotnet build .
 dotnet build . --configuration Release
 ```
 
-### Running C# tests
+#### Running C# tests
 
 ```
 # Set AWS environment credentials and verify that the 'test-registry' exists in AWS Glue.
@@ -32,3 +32,67 @@ export LD_LIBRARY_PATH=/workspaces/aws-glue-schema-registry/native-schema-regist
 dotnet test .
 ```
 
+### Using Csharp Glue Schema client library with KafkaFlow for SerDes
+__Sample serializer usage:__
+
+```csharp
+services.AddKafka(kafka => kafka
+    .UseConsoleLog()
+    .AddCluster(cluster => cluster
+        .WithBrokers(new[] { "localhost:9092" })
+        .AddProducer<CustomerProducer>(producer => producer
+            .DefaultTopic("customer-events")
+            .AddMiddlewares(m => m
+                .AddSerializer<GlueSchemaRegistryKafkaFlowProtobufSerializer<Customer>>(
+                    () => new GlueSchemaRegistryKafkaFlowProtobufSerializer<Customer>("config/gsr-config.properties")
+                )
+            )
+        )
+    )
+);
+```
+
+__Sample deserializer usage:__
+
+```csharp
+.AddConsumer(consumer => consumer
+    .Topic("customer-events")
+    .WithGroupId("customer-group")
+    .WithBufferSize(100)
+    .WithWorkersCount(10)
+    .AddMiddlewares(middlewares => middlewares
+        .AddDeserializer<GlueSchemaRegistryKafkaFlowProtobufDeserializer<Customer>>(
+            () => new GlueSchemaRegistryKafkaFlowProtobufDeserializer<Customer>("config/gsr-config.properties")
+        )
+        .AddTypedHandlers(h => h.AddHandler<CustomerHandler>())
+    )
+)
+```
+
+### Using Csharp Glue Schema client library for Kafka SerDes
+__Sample serializer usage:__
+
+```csharp
+private static readonly string PROTOBUF_CONFIG_PATH = "<PATH_TO_CONFIG_FILE>";
+var protobufSerializer = new GlueSchemaRegistryKafkaSerializer(PROTOBUF_CONFIG_PATH);
+var serialized = protobufSerializer.Serialize(message, message.Descriptor.FullName);
+// send serialized bytes to Kafka using producer.Produce(serialized)
+```
+
+__Sample deserializer usage:__
+
+```csharp
+private static readonly string PROTOBUF_CONFIG_PATH = "<PATH_TO_CONFIG_FILE>";
+var dataConfig = new GlueSchemaRegistryDataFormatConfiguration(
+    new Dictionary<string, dynamic>
+    {
+        { 
+            GlueSchemaRegistryConstants.ProtobufMessageDescriptor, message.Descriptor 
+        }
+    }
+);
+var protobufDeserializer = new GlueSchemaRegistryKafkaDeserializer(PROTOBUF_CONFIG_PATH, dataConfig);
+
+// read message from Kafka using serialized = consumer.Consume()
+var deserializedObject = protobufDeserializer.Deserialize(message.Descriptor.FullName, serialized);
+```

--- a/native-schema-registry/csharp/AWSGsrSerDe/README.md
+++ b/native-schema-registry/csharp/AWSGsrSerDe/README.md
@@ -10,11 +10,25 @@ The C# serializers / de-serializers (SerDes) are built as bindings over existing
 #### Building the C / Java code
 Follow the instructions in those specific projects to build them.
 
-#### Building C# code
+#### Building C# code 
 
 ```
 dotnet clean .
+# For Debug configuration
+dotnet build .
+# For Release configuration
 dotnet build . --configuration Release
+```
+
+### Running C# tests
+
+```
+# Set AWS environment credentials and verify that the 'test-registry' exists in AWS Glue.
+# This ensures that libnativeschemaregistry.so can locate its dependent .so files.
+
+export LD_LIBRARY_PATH=/workspaces/aws-glue-schema-registry/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/bin/Release/net8.0
+
+# Run the test suite
 dotnet test .
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
Add Protobuf serializer and deserializer for KafkaFlow integration + Update CMAKEs for easier dll disovery

*Description of changes:*
__Sample serializer usage:__

```csharp
services.AddKafka(kafka => kafka
    .UseConsoleLog()
    .AddCluster(cluster => cluster
        .WithBrokers(new[] { "localhost:9092" })
        .AddProducer<CustomerProducer>(producer => producer
            .DefaultTopic("customer-events")
            .AddMiddlewares(m => m
                .AddSerializer<GlueSchemaRegistryKafkaFlowProtobufSerializer<Customer>>(
                    () => new GlueSchemaRegistryKafkaFlowProtobufSerializer<Customer>("config/gsr-config.properties")
                )
            )
        )
    )
);
```

__Sample deserializer usage:__

```csharp
.AddConsumer(consumer => consumer
    .Topic("customer-events")
    .WithGroupId("customer-group")
    .WithBufferSize(100)
    .WithWorkersCount(10)
    .AddMiddlewares(middlewares => middlewares
        .AddDeserializer<GlueSchemaRegistryKafkaFlowProtobufDeserializer<Customer>>(
            () => new GlueSchemaRegistryKafkaFlowProtobufDeserializer<Customer>("config/gsr-config.properties")
        )
        .AddTypedHandlers(h => h.AddHandler<CustomerHandler>())
    )
)
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
