### PR TITLE
Add ExceptionMiddleware to handle serialization errors in producers and consumers

### DIFF
--- a/native-schema-registry/ProtobufGSRKafkaDemo/Consumer/Program.cs
+++ b/native-schema-registry/ProtobufGSRKafkaDemo/Consumer/Program.cs
@@ -93,6 +93,7 @@ class Program
                             .WithWorkersCount(1)
                             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
                             .AddMiddlewares(middlewares => middlewares
+                                .Add<ExceptionMiddleware>()
                                 .AddDeserializer(resolver => new GsrProtobufDeserializer<User>(CONFIG_PATH))
                                 .AddTypedHandlers(h => h.AddHandler<UserHandler>())
                             )
@@ -104,6 +105,7 @@ class Program
                             .WithWorkersCount(1)
                             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
                             .AddMiddlewares(middlewares => middlewares
+                                .Add<ExceptionMiddleware>() 
                                 .AddDeserializer(resolver => new GsrProtobufDeserializer<Product>(CONFIG_PATH))
                                 .AddTypedHandlers(h => h.AddHandler<ProductHandler>())
                             )
@@ -115,6 +117,7 @@ class Program
                             .WithWorkersCount(1)
                             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
                             .AddMiddlewares(middlewares => middlewares
+                                .Add<ExceptionMiddleware>()
                                 .AddDeserializer(resolver => new GsrProtobufDeserializer<Order>(CONFIG_PATH))
                                 .AddTypedHandlers(h => h.AddHandler<OrderHandler>())
                             )
@@ -126,6 +129,7 @@ class Program
                             .WithWorkersCount(1)
                             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
                             .AddMiddlewares(middlewares => middlewares
+                                .Add<ExceptionMiddleware>()
                                 .AddDeserializer(resolver => new GsrProtobufDeserializer<Payment>(CONFIG_PATH))
                                 .AddTypedHandlers(h => h.AddHandler<PaymentHandler>())
                             )
@@ -136,7 +140,8 @@ class Program
                             .WithBufferSize(100)
                             .WithWorkersCount(1)
                             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
-                            .AddMiddlewares(middlewares => middlewares
+                            .AddMiddlewares(middlewares => middlewares 
+                                .Add<ExceptionMiddleware>()
                                 .AddDeserializer(resolver => new GsrProtobufDeserializer<Event>(CONFIG_PATH))
                                 .AddTypedHandlers(h => h.AddHandler<EventHandler>())
                             )

--- a/native-schema-registry/ProtobufGSRKafkaDemo/Producer/Program.cs
+++ b/native-schema-registry/ProtobufGSRKafkaDemo/Producer/Program.cs
@@ -73,30 +73,35 @@ class Program
                         .AddProducer("user-producer", producer => producer
                             .DefaultTopic("users")
                             .AddMiddlewares(middlewares => middlewares
+                                .Add<ExceptionMiddleware>()
                                 .AddSerializer(resolver => new GsrProtobufSerializer<User>(CONFIG_PATH))
                             )
                         )
                         .AddProducer("product-producer", producer => producer
                             .DefaultTopic("products")
                             .AddMiddlewares(middlewares => middlewares
+                                .Add<ExceptionMiddleware>()
                                 .AddSerializer(resolver => new GsrProtobufSerializer<Product>(CONFIG_PATH))
                             )
                         )
                         .AddProducer("order-producer", producer => producer
                             .DefaultTopic("orders")
                             .AddMiddlewares(middlewares => middlewares
+                                .Add<ExceptionMiddleware>()
                                 .AddSerializer(resolver => new GsrProtobufSerializer<Order>(CONFIG_PATH))
                             )
                         )
                         .AddProducer("payment-producer", producer => producer
                             .DefaultTopic("payments")
                             .AddMiddlewares(middlewares => middlewares
+                                .Add<ExceptionMiddleware>()
                                 .AddSerializer(resolver => new GsrProtobufSerializer<Payment>(CONFIG_PATH))
                             )
                         )
                         .AddProducer("event-producer", producer => producer
                             .DefaultTopic("events")
                             .AddMiddlewares(middlewares => middlewares
+                                .Add<ExceptionMiddleware>()
                                 .AddSerializer(resolver => new GsrProtobufSerializer<Event>(CONFIG_PATH))
                             )
                         )

--- a/native-schema-registry/ProtobufGSRKafkaDemo/Shared/ExceptionMiddleware.cs
+++ b/native-schema-registry/ProtobufGSRKafkaDemo/Shared/ExceptionMiddleware.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+using KafkaFlow;
+using KafkaFlow.Middlewares;
+
+public class ExceptionMiddleware : IMessageMiddleware
+{
+    public async Task Invoke(IMessageContext context, MiddlewareDelegate next)
+    {
+        try
+        {
+            // Call the next middleware in the pipeline (e.g., serializer)
+            await next(context);
+        }
+        catch (Exception ex)
+        {
+            // Log the error or rethrow it to fail fast
+            Console.WriteLine($"SerDes error for topic '{context.Message}': {ex}");
+
+            // If you want the Produce call to throw:
+            throw;
+        }
+    }
+}


### PR DESCRIPTION

Add ExceptionMiddleware to handle serialization errors in producers and consumers
*Issue #, if available:*

*Description of changes:*

With the exception middleware, we are able to see exception messages in the producer and consumer logs of the demo project.

<img width="1558" height="720" alt="image" src="https://github.com/user-attachments/assets/90d87abe-c7b9-407f-b105-4f0b08141d2a" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
