### PR TITLE
Update native-image configuration to enable additional http URL protocol to hit IMDS + Remove unused native build arguments

### DIFF
--- a/native-schema-registry/pom.xml
+++ b/native-schema-registry/pom.xml
@@ -151,6 +151,8 @@
                                     -H:CLibraryPath=${project.basedir}/c/build/src
                                     -H:ResourceConfigurationFiles=${project.basedir}/src/main/resources/resource-config.json
                                     -H:Name=libnativeschemaregistry.so
+                                    --enable-url-protocols=http,https
+                                    --enable-all-security-services
                                 </buildArgs>
                             </buildArgs>
                         </configuration>

--- a/native-schema-registry/src/main/resources/META-INF/native-image/software.amazon.glue/native-schema-registry/native-image.properties
+++ b/native-schema-registry/src/main/resources/META-INF/native-image/software.amazon.glue/native-schema-registry/native-image.properties
@@ -1,1 +1,1 @@
-Args = --initialize-at-build-time=org.slf4j,com.google.common.jimfs.SystemJimfsFileSystemProvider,com.google.common.jimfs.JimfsFileSystems,com.amazonaws.services.schemaregistry.utils.apicurio.FileDescriptorUtils,com.amazonaws.services.schemaregistry.serializer.ProtobufPreprocessor
+Args = --initialize-at-build-time=org.slf4j,com.google.common.jimfs.SystemJimfsFileSystemProvider,com.google.common.jimfs.JimfsFileSystems


### PR DESCRIPTION
*Description of changes:*

Update native-image configuration to enable additional http URL protocol to hit IMDS + Remove unused native build arguments. This will make sure the compiled native library can pick up EC2 instance roles


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.