### PR TITLE
ISSUE-396: Upgrade AWS SDK v1 and v2 versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <glue.schema.registry.groupId>software.amazon.glue</glue.schema.registry.groupId>
-        <aws.sdk.v2.version>2.22.12</aws.sdk.v2.version>
-        <aws.sdk.v1.version>1.12.660</aws.sdk.v1.version>
+        <aws.sdk.v2.version>2.32.19</aws.sdk.v2.version>
+        <aws.sdk.v1.version>1.12.788</aws.sdk.v1.version>
         <kafka.scala.version>2.12</kafka.scala.version>
         <kafka.version>3.6.1</kafka.version>
         <avro.version>1.11.4</avro.version>


### PR DESCRIPTION
Attempt to address outdated AWS SDK versions. 
https://github.com/awslabs/aws-glue-schema-registry/issues/396

I've built and used locally running via a custom connector in standalone mode.  