### PR TITLE
Update error message in SchemaByDefinitionFetcher for clarity + Increment parent version in pom.xml to 1.1.24

### DIFF
--- a/common/src/main/java/com/amazonaws/services/schemaregistry/common/SchemaByDefinitionFetcher.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/common/SchemaByDefinitionFetcher.java
@@ -94,8 +94,8 @@ public class SchemaByDefinitionFetcher {
             } else {
                 String msg =
                     String.format(
-                        "Exception occurred while fetching or registering schema definition = %s, schema name = %s ",
-                        schemaDefinition, schemaName);
+                        "Exception occurred while fetching or registering schema definition = %s, schema name = %s. Error: %s",
+                        schemaDefinition, schemaName, exceptionCauseMessage);
                 throw new AWSSchemaRegistryException(msg, schemaRegistryException);
             }
             schemaDefinitionToVersionCache.put(schema, schemaVersionId);

--- a/common/src/test/java/com/amazonaws/services/schemaregistry/common/SchemaByDefinitionFetcherTest.java
+++ b/common/src/test/java/com/amazonaws/services/schemaregistry/common/SchemaByDefinitionFetcherTest.java
@@ -192,6 +192,8 @@ public class SchemaByDefinitionFetcherTest {
                 .getORRegisterSchemaVersionId(userSchemaDefinition, schemaName, dataFormatName, getMetadata()));
         assertTrue(
             exception.getMessage().contains("Exception occurred while fetching or registering schema definition"));
+        assertTrue(
+            exception.getMessage().contains("Error: Unknown"));
     }
 
     @Test

--- a/native-schema-registry/pom.xml
+++ b/native-schema-registry/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.10</version>
+        <version>1.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
**Description of changes:**

Update error message in SchemaByDefinitionFetcher for clarity + Increment parent version in pom.xml to 1.1.24

**Before this change**:
<img width="1132" height="515" alt="image" src="https://github.com/user-attachments/assets/e9c43920-94f2-462b-824e-b7bfc3de2203" />


**After this change**:
<img width="1257" height="387" alt="image" src="https://github.com/user-attachments/assets/73f3bb9c-c6b3-414b-a2a1-0ad3cc2d73f2" />


See the highlighted text to the difference in error message logging.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
