### PR TITLE
Fix include path in DataTypes to dynamically resolve directory + Update parent version in pom.xml back to 1.1.10

### DIFF
--- a/native-schema-registry/pom.xml
+++ b/native-schema-registry/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.24</version>
+        <version>1.1.10</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/native-schema-registry/src/main/java/com/amazonaws/services/schemaregistry/DataTypes.java
+++ b/native-schema-registry/src/main/java/com/amazonaws/services/schemaregistry/DataTypes.java
@@ -9,6 +9,8 @@ import org.graalvm.nativeimage.c.type.CCharPointer;
 import org.graalvm.word.PointerBase;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,7 +23,6 @@ public class DataTypes {
      */
     static class HandlerDirectives implements CContext.Directives {
 
-        public static final String INCLUDE_PATH = "<ABSOLUTE_PATH>/native-schema-registry/c/include/";
         public static final String LIB_PATH = "";
         //Intentionally blank.
         public static final String PROJECT_NAME = "";
@@ -40,13 +41,20 @@ public class DataTypes {
 
         @Override
         public List<String> getHeaderFiles() {
+            Path dir = Paths.get(System.getProperty("user.dir"));
+
+            // Construct path to c/include directory
+            Path includePath = dir.getParent().resolve("c").resolve("include");
+
+            // Use the include path for header files
+            String includePathStr = includePath.toString() + "/";
             return Stream.of(
                 "glue_schema_registry_schema.h",
                 "read_only_byte_array.h",
                 "mutable_byte_array.h",
                 "glue_schema_registry_error.h"
             )
-                .map(header -> "\"" + INCLUDE_PATH + header + "\"")
+                .map(header -> "\"" + includePathStr + header + "\"")
                 .collect(Collectors.toList());
         }
     }
@@ -133,3 +141,4 @@ public class DataTypes {
     @CFunction("throw_error")
     public static native void throwError(C_GlueSchemaRegistryErrorPointerHolder pErr, CCharPointer msg, int code);
 }
+


### PR DESCRIPTION

**Description of changes:**

Fix include path in DataTypes to dynamically resolve directory + Update parent version in pom.xml back to 1.1.10

C build - now doesn't need the manual step to set absolute path 
<img width="692" height="37" alt="image" src="https://github.com/user-attachments/assets/a921a414-1dde-491e-8d36-6290fab910e3" />


Csharp tests
<img width="953" height="191" alt="image" src="https://github.com/user-attachments/assets/4ee04137-3d00-4dd9-8a83-adecf90261dc" />




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
