### PR TITLE
Onboard Musl variant of the native library 

### DIFF
--- a/native-schema-registry/build/musl/Dockerfile
+++ b/native-schema-registry/build/musl/Dockerfile
@@ -1,0 +1,98 @@
+# ==========================
+# Stage 1 — Java build (GraalVM musl)
+# ==========================
+FROM ghcr.io/graalvm/native-image-community:17-muslib AS java-build
+
+WORKDIR /tmp
+
+# Build PIC-compatible zlib to fix shared library linking
+RUN curl -L https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.tar.gz | tar -xz && \
+    cd zlib-1.3 && \
+    CC=x86_64-linux-musl-gcc CFLAGS="-fPIC -O2" ./configure --static && \
+    make && \
+    cp libz.a /usr/local/musl/lib/libz.a
+
+# Copy the project
+COPY . .
+
+# Install packages for Java build
+RUN microdnf install -y maven git unzip zip curl bash findutils ca-certificates tar gzip \
+ && microdnf clean all
+
+# Install packages for C build
+RUN microdnf install -y dnf dnf-plugins-core && \
+    dnf -y config-manager --set-enabled ol9_codeready_builder && \
+    dnf -y install oracle-epel-release-el9 && \
+    dnf -y --enablerepo=ol9_developer_EPEL install swig lcov gcc clang clang-tools-extra make cmake && \
+    dnf clean all && rm -rf /var/cache/dnf
+
+# Build core Java library
+RUN mvn -U clean install -Dcheckstyle.skip=true -DskipTests
+RUN pwd
+# Build  C native libraries
+WORKDIR /tmp/native-schema-registry/c
+RUN cmake -S . -B build \
+  -DCMAKE_C_COMPILER=x86_64-linux-musl-gcc \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON 
+WORKDIR /tmp/native-schema-registry/c/build
+RUN cmake --build . || true
+
+# Build Java native-image profile
+WORKDIR /tmp/native-schema-registry
+RUN mvn clean install -P native-image-musl -DskipTests -Dcheckstyle.skip=true
+
+# ==========================
+# Stage 2 — Alpine latest (C + C# builds)
+# ==========================
+FROM alpine:latest
+
+WORKDIR /tmp
+COPY --from=java-build /tmp /tmp
+
+# Install dependencies for C and C#
+RUN apk add --no-cache \
+    bash git curl ca-certificates unzip zip findutils \
+    build-base cmake musl-dev clang clang-extra-tools llvm \
+    swig lcov protobuf protobuf-dev protoc \
+    dotnet8-sdk
+
+# --- C build ---
+WORKDIR /tmp/native-schema-registry/c
+RUN rm -rf build
+RUN cmake -S . -B build && cmake --build build
+
+# --- C# build ---
+
+ARG AWS_ACCESS_KEY_ID
+ARG AWS_SECRET_ACCESS_KEY
+ARG AWS_SESSION_TOKEN
+ENV AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
+ENV AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
+ENV AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN
+
+WORKDIR /tmp/native-schema-registry/csharp/AWSGsrSerDe
+
+# fails because protoc doesn't work with Alpine (musl libc based image)
+RUN dotnet clean . && dotnet build . || true
+
+# workaround because protoc from grpc.tools is not compatible with Alpine
+# this is only for the protoc compilation, and doesnt not affect functionality of the library
+RUN apk update \
+    && apk --no-cache add libc6-compat \
+    && apk --no-cache add \ 
+    -X https://dl-cdn.alpinelinux.org/alpine/v3.17/main \
+    -X https://dl-cdn.alpinelinux.org/alpine/v3.17/community \
+    protobuf=3.21.9-r0 \
+    && cd /root/.nuget/packages/grpc.tools/2.48.1/tools/linux_x64 \
+    && rm protoc \
+    && ln -s /usr/bin/protoc protoc \
+    && chmod +x grpc_csharp_plugin
+
+# RUN ls -l /root/.nuget/packages/grpc.tools/2.48.1/tools/linux_x64/ && \
+#     file /root/.nuget/packages/grpc.tools/2.48.1/tools/linux_x64/protoc || true && \
+#     ldd /root/.nuget/packages/grpc.tools/2.48.1/tools/linux_x64/protoc || true
+
+# need to build it twice due to protobuf compilation misorder (normal for csharp builds today)
+RUN dotnet build . || true 
+RUN dotnet build . && dotnet test . || true
+

--- a/native-schema-registry/build/musl/Dockerfile
+++ b/native-schema-registry/build/musl/Dockerfile
@@ -29,7 +29,9 @@ RUN microdnf install -y dnf dnf-plugins-core && \
 # Build core Java library
 RUN mvn -U clean install -Dcheckstyle.skip=true -DskipTests
 RUN pwd
-# Build  C native libraries
+
+# TODO: remove this workaround when we have a straightforward way to build java first and then c
+# Build  C native libraries - just for java build to work as there is a dependency on c headers
 WORKDIR /tmp/native-schema-registry/c
 RUN cmake -S . -B build \
   -DCMAKE_C_COMPILER=x86_64-linux-musl-gcc \

--- a/native-schema-registry/build/musl/README.md
+++ b/native-schema-registry/build/musl/README.md
@@ -1,0 +1,14 @@
+# Instructions to build the native library with musl libc and run Csharp tests on an Alpine image
+
+1. Set AWS credentials AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN
+
+2. From top directory of the pkg `aws-glue-schema-registry`, run
+```
+docker build \
+--build-arg AWS_ACCESS_KEY_ID=<Your AWS Access Key ID> \
+--build-arg AWS_SECRET_ACCESS_KEY=<Your AWS Secret Access Key> \
+--build-arg AWS_SESSION_TOKEN=<Your AWS Session Token> \
+-t native-schema-registry-musl \ 
+-f native-schema-registry/build/musl/Dockerfile . \
+--progress=plain
+```

--- a/native-schema-registry/c/src/CMakeLists.txt
+++ b/native-schema-registry/c/src/CMakeLists.txt
@@ -27,15 +27,16 @@ set_target_properties(${DATA_TYPES_MODULE_NAME} PROPERTIES
     BUILD_RPATH "$ORIGIN"
     INSTALL_RPATH "$ORIGIN"
 )
-add_custom_command(
-        TARGET ${DATA_TYPES_MODULE_NAME}
-        POST_BUILD
-        COMMENT "copying data types for maven project build"
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${DATA_TYPES_MODULE_NAME}> ${LIB_NATIVE_SCHEMA_REGISTRY_PATH}/
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_LINKER_FILE:${DATA_TYPES_MODULE_NAME}> ${LIB_NATIVE_SCHEMA_REGISTRY_PATH}/
-        COMMENT "building maven project, native image target"
-        COMMAND mvn clean install -P native-image WORKING_DIRECTORY ${MAVEN_PROJECT_DIR}/..
-)
+# We should revert from this way of compiling Java from C dir because we would be compiling Java in a separate graalvm image for the musl variant of the library
+# add_custom_command(
+#         TARGET ${DATA_TYPES_MODULE_NAME}
+#         POST_BUILD
+#         COMMENT "copying data types for maven project build"
+#         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${DATA_TYPES_MODULE_NAME}> ${LIB_NATIVE_SCHEMA_REGISTRY_PATH}/
+#         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_LINKER_FILE:${DATA_TYPES_MODULE_NAME}> ${LIB_NATIVE_SCHEMA_REGISTRY_PATH}/
+#         COMMENT "building maven project, native image target"
+#         COMMAND mvn clean install -P native-image WORKING_DIRECTORY ${MAVEN_PROJECT_DIR}/..
+# )
 
 #Add reference to the GraalVM generated Native schema registry module.
 #First, fix the include path in GraalVM generated header file.

--- a/native-schema-registry/pom.xml
+++ b/native-schema-registry/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.10</version>
+        <version>1.1.24</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -151,6 +151,42 @@
                                     -H:CLibraryPath=${project.basedir}/c/build/src
                                     -H:ResourceConfigurationFiles=${project.basedir}/src/main/resources/resource-config.json
                                     -H:Name=libnativeschemaregistry.so
+                                    --enable-url-protocols=http
+                                </buildArgs>
+                            </buildArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>native-image-musl</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.graalvm.nativeimage</groupId>
+                        <artifactId>native-image-maven-plugin</artifactId>
+                        <version>${graalvm.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>native-image</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <imageName>libnativeschemaregistry</imageName>
+                            <buildArgs combine.children="append">
+                                <buildArgs>
+                                    --verbose
+                                    --no-fallback
+                                    --shared
+                                    -g
+                                    -H:CLibraryPath=${project.basedir}/c/build/src
+                                    -H:ResourceConfigurationFiles=${project.basedir}/src/main/resources/resource-config.json
+                                    -H:Name=libnativeschemaregistry.so
+                                    --libc=musl
                                     --enable-url-protocols=http
                                 </buildArgs>
                             </buildArgs>


### PR DESCRIPTION
This PR:

1. Creates a maven build profile for musl java native library compilation
2. Onboards a Dockerfile showcasing an E2E C# run on Alpine Linux (which comes with musl libc)
3. Includes a musl build README showcasing steps to compile java using graalvm/musl and proceed run C# tests

Dockerfile builds all the way up-to C# layer and the tests work fine (except getCType errors which we are solving in a follow up PR)
<img width="701" height="274" alt="image" src="https://github.com/user-attachments/assets/47b19b55-0fbf-45df-a237-c79ef590f3a9" />


While the current solution works, there are ToDos that need to be fixed as follow up PRs:
1. Permanently update library to 1.1.24 version across all modules and solve getCType errors
2. Fix C tests that do not work with musl as cmocka is not musl libc compatible 
