### PR TITLE
Enhance error message in SchemaByDefinitionFetcher to include exception cause and update corresponding test case

### DIFF
--- a/common/src/main/java/com/amazonaws/services/schemaregistry/common/SchemaByDefinitionFetcher.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/common/SchemaByDefinitionFetcher.java
@@ -94,8 +94,8 @@ public class SchemaByDefinitionFetcher {
             } else {
                 String msg =
                     String.format(
-                        "Exception occurred while fetching or registering schema definition = %s, schema name = %s ",
-                        schemaDefinition, schemaName);
+                        "Exception occurred while fetching or registering schema definition = %s, schema name = %s. Error: %s",
+                        schemaDefinition, schemaName, exceptionCauseMessage);
                 throw new AWSSchemaRegistryException(msg, schemaRegistryException);
             }
             schemaDefinitionToVersionCache.put(schema, schemaVersionId);

--- a/common/src/test/java/com/amazonaws/services/schemaregistry/common/SchemaByDefinitionFetcherTest.java
+++ b/common/src/test/java/com/amazonaws/services/schemaregistry/common/SchemaByDefinitionFetcherTest.java
@@ -192,6 +192,8 @@ public class SchemaByDefinitionFetcherTest {
                 .getORRegisterSchemaVersionId(userSchemaDefinition, schemaName, dataFormatName, getMetadata()));
         assertTrue(
             exception.getMessage().contains("Exception occurred while fetching or registering schema definition"));
+        assertTrue(
+            exception.getMessage().contains("Error: Unknown"));
     }
 
     @Test


### PR DESCRIPTION
Enhance error message in SchemaByDefinitionFetcher to include exception cause and update corresponding test case

Originally PR'ed here: https://github.com/awslabs/aws-glue-schema-registry/pull/400