### PR TITLE
Update CMake configuration for Maven project build integration so that we can build C + Java stack with a single command

### DIFF
--- a/native-schema-registry/c/CMakeLists.txt
+++ b/native-schema-registry/c/CMakeLists.txt
@@ -7,6 +7,7 @@ project(native_schema_registry_c C)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+set(MAVEN_PROJECT_DIR "${PROJECT_SOURCE_DIR}/../target")
 ##Global variables
 #Path to GraalVM generated shared library
 set(LIB_NATIVE_SCHEMA_REGISTRY_PATH "${PROJECT_SOURCE_DIR}/../target")

--- a/native-schema-registry/c/src/CMakeLists.txt
+++ b/native-schema-registry/c/src/CMakeLists.txt
@@ -4,7 +4,7 @@ include(cmake/FetchAwsCommon.cmake)
 if (CMAKE_SYSTEM_NAME MATCHES "^(Linux)$")
         list(APPEND TEST_COVERAGE "-ftest-coverage -fprofile-arcs")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${TEST_COVERAGE} -g -O0 -Wall")
-        set(CMAKE_C_CLANG_TIDY clang-tidy -checks=-*,readability-*)
+        set(CMAKE_C_CLANG_TIDY clang-tidy -checks=-*,readability-*,-readability-math-missing-parentheses)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lgcov")
 endif()
 
@@ -30,13 +30,19 @@ set_target_properties(${DATA_TYPES_MODULE_NAME} PROPERTIES
 add_custom_command(
         TARGET ${DATA_TYPES_MODULE_NAME}
         POST_BUILD
+        COMMENT "copying data types for maven project build"
         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${DATA_TYPES_MODULE_NAME}> ${LIB_NATIVE_SCHEMA_REGISTRY_PATH}/
         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_LINKER_FILE:${DATA_TYPES_MODULE_NAME}> ${LIB_NATIVE_SCHEMA_REGISTRY_PATH}/
+        COMMENT "building maven project, native image target"
+        COMMAND mvn clean install -P native-image WORKING_DIRECTORY ${MAVEN_PROJECT_DIR}/..
 )
 
 #Add reference to the GraalVM generated Native schema registry module.
 #First, fix the include path in GraalVM generated header file.
-execute_process(COMMAND sed -ie "s/<graal_isolate.h>/\"graal_isolate.h\"/" ${LIB_NATIVE_SCHEMA_REGISTRY_PATH}/libnativeschemaregistry.h)
+execute_process(
+        COMMAND sed -ie "s/<graal_isolate.h>/\"graal_isolate.h\"/" ${LIB_NATIVE_SCHEMA_REGISTRY_PATH}/libnativeschemaregistry.h
+        COMMENT "fixed include path in GraalVM generated header file"
+)
 add_library(
         ${NATIVE_SCHEMA_REGISTRY_MODULE_NAME} SHARED
         IMPORTED


### PR DESCRIPTION
Update CMake configuration for Maven project build integration so that we can build C + Java stack with a single command

*Issue #, if available:*

*Description of changes:*
PR'ed here: https://github.com/awslabs/aws-glue-schema-registry/pull/398

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
