### PR TITLE
AWS SDK version upgrade + fix flaky integ test.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,3 +96,6 @@ GlueSchemaRegistryKafkaSerializer/GlueSchemaRegistryKafkaDeserializer.
 
 ## Release 1.1.24
 * Upgraded square-wireschema version to fix vulnerabilities
+
+## Release 1.1.25
+* Upgraded aws-sdk version to fix vulnerabilities

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The recommended way to use the AWS Glue Schema Registry Library for Java is to c
   <dependency>
       <groupId>software.amazon.glue</groupId>
       <artifactId>schema-registry-serde</artifactId>
-      <version>1.1.24</version>
+      <version>1.1.25</version>
   </dependency>
   ```
 ### Code Example
@@ -490,7 +490,7 @@ It should look like this
 * If using bash, run the below commands to set-up your CLASSPATH in your bash_profile. (For any other shell, update the environment accordingly.)
   ```bash
       echo 'export GSR_LIB_BASE_DIR=<>' >>~/.bash_profile
-      echo 'export GSR_LIB_VERSION=1.1.24' >>~/.bash_profile
+      echo 'export GSR_LIB_VERSION=1.1.25' >>~/.bash_profile
       echo 'export KAFKA_HOME=<your kafka installation directory>' >>~/.bash_profile
       echo 'export CLASSPATH=$CLASSPATH:$GSR_LIB_BASE_DIR/avro-kafkaconnect-converter/target/schema-registry-kafkaconnect-converter-$GSR_LIB_VERSION.jar:$GSR_LIB_BASE_DIR/common/target/schema-registry-common-$GSR_LIB_VERSION.jar:$GSR_LIB_BASE_DIR/avro-serializer-deserializer/target/schema-registry-serde-$GSR_LIB_VERSION.jar' >>~/.bash_profile
       source ~/.bash_profile
@@ -549,7 +549,7 @@ It should look like this
   <dependency>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-kafkastreams-serde</artifactId>
-        <version>1.1.24</version>
+        <version>1.1.25</version>
   </dependency>
   ```
 
@@ -587,7 +587,7 @@ repository for the latest support: [Avro SerializationSchema and Deserialization
   <dependency>
        <groupId>software.amazon.glue</groupId>
        <artifactId>schema-registry-flink-serde</artifactId>
-       <version>1.1.24</version>
+       <version>1.1.25</version>
   </dependency>
   ```
 ### Code Example

--- a/avro-flink-serde/pom.xml
+++ b/avro-flink-serde/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>software.amazon.glue</groupId>
     <artifactId>schema-registry-flink-serde</artifactId>
-    <version>1.1.24</version>
+    <version>1.1.25</version>
     <name>AWS Glue Schema Registry Flink Avro Serialization Deserialization Schema</name>
     <description>The AWS Glue Schema Registry Library for Apache Flink enables Java developers to easily integrate
         their Apache Flink applications with AWS Glue Schema Registry
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-serde</artifactId>
-            <version>1.1.24</version>
+            <version>1.1.25</version>
         </dependency>
         <dependency>
           <groupId>org.projectlombok</groupId>

--- a/avro-kafkaconnect-converter/pom.xml
+++ b/avro-kafkaconnect-converter/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.24</version>
+        <version>1.1.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.24</version>
+        <version>1.1.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.24</version>
+        <version>1.1.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.24</version>
+        <version>1.1.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.24</version>
+        <version>1.1.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kinesis/GlueSchemaRegistryKinesisIntegrationTest.java
+++ b/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kinesis/GlueSchemaRegistryKinesisIntegrationTest.java
@@ -416,9 +416,10 @@ public class GlueSchemaRegistryKinesisIntegrationTest {
 
             byte[] gsrEncodedBytes = glueSchemaRegistrySerializer.encode(streamName, gsrSchema, serializedBytes);
 
+            String partitionKey = String.valueOf(timestamp.toEpochMilli()) + "-" + i;
             PutRecordRequest putRecordRequest = PutRecordRequest.builder()
                     .streamName(streamName)
-                    .partitionKey(String.valueOf(timestamp.toEpochMilli()))
+                    .partitionKey(partitionKey)
                     .data(SdkBytes.fromByteArray(gsrEncodedBytes))
                     .build();
             shardId = kinesisClient.putRecord(putRecordRequest)
@@ -510,7 +511,8 @@ public class GlueSchemaRegistryKinesisIntegrationTest {
 
             byte[] serializedBytes = dataFormatSerializer.serialize(record);
 
-            putFutures.add(producer.addUserRecord(streamName, Long.toString(timestamp.toEpochMilli()), null,
+            String partitionKey = Long.toString(timestamp.toEpochMilli()) + "-" + i;
+            putFutures.add(producer.addUserRecord(streamName, partitionKey, null,
                                                   ByteBuffer.wrap(serializedBytes),gsrSchema));
         }
 

--- a/jsonschema-kafkaconnect-converter/pom.xml
+++ b/jsonschema-kafkaconnect-converter/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.24</version>
+        <version>1.1.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kafkastreams-serde/pom.xml
+++ b/kafkastreams-serde/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.24</version>
+        <version>1.1.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>software.amazon.glue</groupId>
     <artifactId>schema-registry-parent</artifactId>
-    <version>1.1.24</version>
+    <version>1.1.25</version>
     <packaging>pom</packaging>
     <name>AWS Glue Schema Registry Library</name>
     <description>The AWS Glue Schema Registry Library for Java enables Java developers to easily integrate their
@@ -80,7 +80,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <glue.schema.registry.groupId>software.amazon.glue</glue.schema.registry.groupId>
-        <aws.sdk.v2.version>2.22.12</aws.sdk.v2.version>
+        <aws.sdk.v2.version>2.32.25</aws.sdk.v2.version>
         <aws.sdk.v1.version>1.12.660</aws.sdk.v1.version>
         <kafka.scala.version>2.12</kafka.scala.version>
         <kafka.version>3.6.1</kafka.version>

--- a/protobuf-kafkaconnect-converter/pom.xml
+++ b/protobuf-kafkaconnect-converter/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.24</version>
+        <version>1.1.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/serializer-deserializer-msk-iam/pom.xml
+++ b/serializer-deserializer-msk-iam/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.24</version>
+        <version>1.1.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/serializer-deserializer/pom.xml
+++ b/serializer-deserializer/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.24</version>
+        <version>1.1.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
*Issue #, if available:* [396](https://github.com/awslabs/aws-glue-schema-registry/issues/396)

*Description of changes:*

- AWS SDK version upgrade from 2.22.12 to 2.32.25.
- Improve test `testProduceConsumeWithKPLAndKCL` to avoid occasional partition dups when creating entries. That seems to resolve test flakiness.

*Test*
```
[INFO] Results:
[INFO] 
[INFO] Tests run: 72, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
````

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
