### PR TITLE
Added negative integration tests for configuration sad paths.

### DIFF
--- a/native-schema-registry/golang/integration-tests/negative_test/configs/invalid_role_to_assume.properties
+++ b/native-schema-registry/golang/integration-tests/negative_test/configs/invalid_role_to_assume.properties
@@ -7,3 +7,4 @@ registry.name=default-registry
 description=Multi-threaded Protobuf GSR Kafka Demo with 5 message types
 compatibility=FORWARD
 schemaAutoRegistrationEnabled=true
+roleToAssume=arn:aws:iam::111111111111:role/Admin

--- a/native-schema-registry/golang/integration-tests/negative_test/configs/non_existant_endpoint.properties
+++ b/native-schema-registry/golang/integration-tests/negative_test/configs/non_existant_endpoint.properties
@@ -1,5 +1,5 @@
 region=us-east-1
-endpoint=https://glue.us-east-1.amazonaws.com
+endpoint=https://glue.not-a-real-endpoint.us-east-1.amazonaws.com
 # proxyUrl=http://your-proxy:8080
 
 # Schema Registry Configuration

--- a/native-schema-registry/golang/integration-tests/negative_test/configs/non_existant_region.properties
+++ b/native-schema-registry/golang/integration-tests/negative_test/configs/non_existant_region.properties
@@ -1,4 +1,4 @@
-region=us-east-1
+region=us-soutweast-1
 endpoint=https://glue.us-east-1.amazonaws.com
 # proxyUrl=http://your-proxy:8080
 

--- a/native-schema-registry/golang/integration-tests/negative_test/configs/non_existant_registry.properties
+++ b/native-schema-registry/golang/integration-tests/negative_test/configs/non_existant_registry.properties
@@ -3,7 +3,7 @@ endpoint=https://glue.us-east-1.amazonaws.com
 # proxyUrl=http://your-proxy:8080
 
 # Schema Registry Configuration
-registry.name=default-registry
+registry.name=this-registry-does-not-exist
 description=Multi-threaded Protobuf GSR Kafka Demo with 5 message types
 compatibility=FORWARD
 schemaAutoRegistrationEnabled=true

--- a/native-schema-registry/golang/integration-tests/negative_test/configuration_test.go
+++ b/native-schema-registry/golang/integration-tests/negative_test/configuration_test.go
@@ -1,0 +1,279 @@
+package negative_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/awslabs/aws-glue-schema-registry/native-schema-registry/golang/integration-tests/testpb/syntax2/basic"
+	"github.com/awslabs/aws-glue-schema-registry/native-schema-registry/golang/pkg/gsrserde-go/common"
+	"github.com/awslabs/aws-glue-schema-registry/native-schema-registry/golang/pkg/gsrserde-go/deserializer"
+	"github.com/awslabs/aws-glue-schema-registry/native-schema-registry/golang/pkg/gsrserde-go/serializer"
+)
+
+type ConfigurationTestSuite struct {
+	suite.Suite
+}
+
+const (
+	MISSING_PATH           = "missing_path"
+	INVALID_ROLE_TO_ASSUME = "./configs/invalid_role_to_assume.properties"
+	NON_EXISTANT_REGISTRY  = "./configs/non_existant_registry.properties"
+	NON_EXISTANT_ENDPOINT  = "./configs/non_existant_endpoint.properties"
+	NON_EXISTANT_REGION    = "./configs/non_existant_region.properties"
+)
+
+// createTestPhone creates a valid Phone protobuf message for testing
+func (c *ConfigurationTestSuite) createTestPhone() *basic.Phone {
+	return &basic.Phone{
+		Model:  proto.String("iPhone 15"),
+		Name:   proto.String("Test Phone"),
+		Serial: proto.Int32(12345),
+	}
+}
+
+// createProtobufConfig creates a protobuf configuration with the given config path
+func (c *ConfigurationTestSuite) createProtobufConfig(configPath string) *common.Configuration {
+	phone := c.createTestPhone()
+	messageDescriptor := phone.ProtoReflect().Descriptor()
+
+	configMap := map[string]interface{}{
+		common.DataFormatTypeKey:            common.DataFormatProtobuf,
+		common.ProtobufMessageDescriptorKey: messageDescriptor,
+		common.GSRConfigPathKey:             configPath,
+	}
+
+	return common.NewConfiguration(configMap)
+}
+
+// TestSerializerWithMissingPath tests serializer creation with missing config path
+func (c *ConfigurationTestSuite) TestSerializerWithMissingPath() {
+	c.T().Log("Testing serializer with missing configuration path...")
+
+	config := c.createProtobufConfig(MISSING_PATH)
+	phone := c.createTestPhone()
+
+	// Attempt to create serializer with missing config path
+	gsrSerializer, err := serializer.NewSerializer(config)
+	if err != nil {
+		// Expected: serializer creation should fail
+		c.T().Logf("✓ Serializer creation failed as expected: %v", err)
+		require.Error(c.T(), err, "Serializer creation should fail with missing config path")
+		return
+	}
+
+	// If serializer creation succeeds, try to serialize and expect it to fail
+	defer gsrSerializer.Close()
+
+	transportName := "test-transport"
+	_, serializeErr := gsrSerializer.Serialize(transportName, phone)
+	require.Error(c.T(), serializeErr, "Serialize should fail with missing config path")
+	c.T().Logf("✓ Serialize operation failed as expected: %v", serializeErr)
+}
+
+// TestSerializerWithInvalidRoleToAssume tests serializer with invalid role configuration
+func (c *ConfigurationTestSuite) TestSerializerWithInvalidRoleToAssume() {
+	c.T().Log("Testing serializer with invalid role to assume...")
+
+	config := c.createProtobufConfig(INVALID_ROLE_TO_ASSUME)
+	phone := c.createTestPhone()
+
+	gsrSerializer, err := serializer.NewSerializer(config)
+	if err != nil {
+		c.T().Logf("✓ Serializer creation failed as expected: %v", err)
+		require.Error(c.T(), err, "Serializer creation should fail with invalid role")
+		return
+	}
+
+	defer gsrSerializer.Close()
+
+	transportName := "test-transport"
+	_, serializeErr := gsrSerializer.Serialize(transportName, phone)
+	require.Error(c.T(), serializeErr, "Serialize should fail with invalid role configuration")
+	c.T().Logf("✓ Serialize operation failed as expected: %v", serializeErr)
+}
+
+// TestSerializerWithNonExistentRegistry tests serializer with non-existent registry
+func (c *ConfigurationTestSuite) TestSerializerWithNonExistentRegistry() {
+	c.T().Log("Testing serializer with non-existent registry...")
+
+	config := c.createProtobufConfig(NON_EXISTANT_REGISTRY)
+	phone := c.createTestPhone()
+
+	gsrSerializer, err := serializer.NewSerializer(config)
+	if err != nil {
+		c.T().Logf("✓ Serializer creation failed as expected: %v", err)
+		require.Error(c.T(), err, "Serializer creation should fail with non-existent registry")
+		return
+	}
+
+	defer gsrSerializer.Close()
+
+	transportName := "test-transport"
+	_, serializeErr := gsrSerializer.Serialize(transportName, phone)
+	require.Error(c.T(), serializeErr, "Serialize should fail with non-existent registry")
+	c.T().Logf("✓ Serialize operation failed as expected: %v", serializeErr)
+}
+
+// TestSerializerWithNonExistentEndpoint tests serializer with non-existent endpoint
+func (c *ConfigurationTestSuite) TestSerializerWithNonExistentEndpoint() {
+	c.T().Log("Testing serializer with non-existent endpoint...")
+
+	config := c.createProtobufConfig(NON_EXISTANT_ENDPOINT)
+	phone := c.createTestPhone()
+
+	gsrSerializer, err := serializer.NewSerializer(config)
+	if err != nil {
+		c.T().Logf("✓ Serializer creation failed as expected: %v", err)
+		require.Error(c.T(), err, "Serializer creation should fail with non-existent endpoint")
+		return
+	}
+
+	defer gsrSerializer.Close()
+
+	transportName := "test-transport"
+	_, serializeErr := gsrSerializer.Serialize(transportName, phone)
+	require.Error(c.T(), serializeErr, "Serialize should fail with non-existent endpoint")
+	c.T().Logf("✓ Serialize operation failed as expected: %v", serializeErr)
+}
+
+// TestSerializerWithNonExistentRegion tests serializer with non-existent region
+func (c *ConfigurationTestSuite) TestSerializerWithNonExistentRegion() {
+	c.T().Log("Testing serializer with non-existent region...")
+
+	config := c.createProtobufConfig(NON_EXISTANT_REGION)
+	phone := c.createTestPhone()
+
+	gsrSerializer, err := serializer.NewSerializer(config)
+	if err != nil {
+		c.T().Logf("✓ Serializer creation failed as expected: %v", err)
+		require.Error(c.T(), err, "Serializer creation should fail with non-existent region")
+		return
+	}
+
+	defer gsrSerializer.Close()
+
+	transportName := "test-transport"
+	_, serializeErr := gsrSerializer.Serialize(transportName, phone)
+	require.Error(c.T(), serializeErr, "Serialize should fail with non-existent region")
+	c.T().Logf("✓ Serialize operation failed as expected: %v", serializeErr)
+}
+
+// TestDeserializerWithMissingPath tests deserializer creation with missing config path
+func (c *ConfigurationTestSuite) TestDeserializerWithMissingPath() {
+	c.T().Log("Testing deserializer with missing configuration path...")
+
+	config := c.createProtobufConfig(MISSING_PATH)
+
+	// Attempt to create deserializer with missing config path
+	gsrDeserializer, err := deserializer.NewDeserializer(config)
+	if err != nil {
+		c.T().Logf("✓ Deserializer creation failed as expected: %v", err)
+		require.Error(c.T(), err, "Deserializer creation should fail with missing config path")
+		return
+	}
+
+	defer gsrDeserializer.Close()
+
+	// Try to use deserializer methods with dummy data and expect failures
+	dummyData := []byte{0x01, 0x02, 0x03, 0x04}
+
+	_, canDecodeErr := gsrDeserializer.CanDeserialize(dummyData)
+	require.Error(c.T(), canDecodeErr, "CanDeserialize should fail with missing config")
+	c.T().Logf("✓ CanDeserialize failed as expected: %v", canDecodeErr)
+
+	_, decodeErr := gsrDeserializer.Deserialize("test-topic", dummyData)
+	require.Error(c.T(), decodeErr, "Deserialize should fail with missing config")
+	c.T().Logf("✓ Deserialize failed as expected: %v", decodeErr)
+}
+
+// TestDeserializerWithInvalidRoleToAssume tests deserializer with invalid role configuration
+func (c *ConfigurationTestSuite) TestDeserializerWithInvalidRoleToAssume() {
+	c.T().Log("Testing deserializer with invalid role to assume...")
+
+	config := c.createProtobufConfig(INVALID_ROLE_TO_ASSUME)
+
+	gsrDeserializer, err := deserializer.NewDeserializer(config)
+	if err != nil {
+		c.T().Logf("✓ Deserializer creation failed as expected: %v", err)
+		require.Error(c.T(), err, "Deserializer creation should fail with invalid role")
+		return
+	}
+
+	defer gsrDeserializer.Close()
+
+	dummyData := []byte{0x01, 0x02, 0x03, 0x04}
+	_, decodeErr := gsrDeserializer.Deserialize("test-topic", dummyData)
+	require.Error(c.T(), decodeErr, "Deserialize should fail with invalid role configuration")
+	c.T().Logf("✓ Deserialize operation failed as expected: %v", decodeErr)
+}
+
+// TestDeserializerWithNonExistentRegistry tests deserializer with non-existent registry
+func (c *ConfigurationTestSuite) TestDeserializerWithNonExistentRegistry() {
+	c.T().Log("Testing deserializer with non-existent registry...")
+
+	config := c.createProtobufConfig(NON_EXISTANT_REGISTRY)
+
+	gsrDeserializer, err := deserializer.NewDeserializer(config)
+	if err != nil {
+		c.T().Logf("✓ Deserializer creation failed as expected: %v", err)
+		require.Error(c.T(), err, "Deserializer creation should fail with non-existent registry")
+		return
+	}
+
+	defer gsrDeserializer.Close()
+
+	dummyData := []byte{0x01, 0x02, 0x03, 0x04}
+	_, decodeErr := gsrDeserializer.Deserialize("test-topic", dummyData)
+	require.Error(c.T(), decodeErr, "Deserialize should fail with non-existent registry")
+	c.T().Logf("✓ Deserialize operation failed as expected: %v", decodeErr)
+}
+
+// TestDeserializerWithNonExistentEndpoint tests deserializer with non-existent endpoint
+func (c *ConfigurationTestSuite) TestDeserializerWithNonExistentEndpoint() {
+	c.T().Log("Testing deserializer with non-existent endpoint...")
+
+	config := c.createProtobufConfig(NON_EXISTANT_ENDPOINT)
+
+	gsrDeserializer, err := deserializer.NewDeserializer(config)
+	if err != nil {
+		c.T().Logf("✓ Deserializer creation failed as expected: %v", err)
+		require.Error(c.T(), err, "Deserializer creation should fail with non-existent endpoint")
+		return
+	}
+
+	defer gsrDeserializer.Close()
+
+	dummyData := []byte{0x01, 0x02, 0x03, 0x04}
+	_, decodeErr := gsrDeserializer.Deserialize("test-topic", dummyData)
+	require.Error(c.T(), decodeErr, "Deserialize should fail with non-existent endpoint")
+	c.T().Logf("✓ Deserialize operation failed as expected: %v", decodeErr)
+}
+
+// TestDeserializerWithNonExistentRegion tests deserializer with non-existent region
+func (c *ConfigurationTestSuite) TestDeserializerWithNonExistentRegion() {
+	c.T().Log("Testing deserializer with non-existent region...")
+
+	config := c.createProtobufConfig(NON_EXISTANT_REGION)
+
+	gsrDeserializer, err := deserializer.NewDeserializer(config)
+	if err != nil {
+		c.T().Logf("✓ Deserializer creation failed as expected: %v", err)
+		require.Error(c.T(), err, "Deserializer creation should fail with non-existent region")
+		return
+	}
+
+	defer gsrDeserializer.Close()
+
+	dummyData := []byte{0x01, 0x02, 0x03, 0x04}
+	_, decodeErr := gsrDeserializer.Deserialize("test-topic", dummyData)
+	require.Error(c.T(), decodeErr, "Deserialize should fail with non-existent region")
+	c.T().Logf("✓ Deserialize operation failed as expected: %v", decodeErr)
+}
+
+// TestConfigurationTestSuite runs the configuration negative test suite
+func TestConfigurationTestSuite(t *testing.T) {
+	suite.Run(t, new(ConfigurationTestSuite))
+}


### PR DESCRIPTION
This pull request adds a comprehensive suite of negative configuration tests for the Go integration tests of the Glue Schema Registry (GSR) Protobuf serializer and deserializer. It introduces new test cases to ensure that the system fails gracefully and as expected when provided with invalid or non-existent configuration values. The changes include both the new test logic and the necessary configuration files for various negative scenarios.

Negative configuration testing improvements:

* Added a new test suite in `configuration_test.go` that verifies the serializer and deserializer correctly handle missing configuration paths, invalid roles, non-existent registries, endpoints, and regions, ensuring robust error handling for misconfigurations.
* Created new configuration files for negative test scenarios, including invalid role to assume (`invalid_role_to_assume.properties`), non-existent registry (`non_existant_registry.properties`), non-existent endpoint (`non_existant_endpoint.properties`), and non-existent region (`non_existant_region.properties`). [[1]](diffhunk://#diff-1142a3ebdc2bf65e7ee9458f7ddcdcca43b2aca11ae1b9de43ce4ca7a741d7fbR1-R10) [[2]](diffhunk://#diff-6f6ac1cb3d3c014c92c174c87ef4b20f28d1688c7ba1369196441bb58f3cbde7R1-R9) [[3]](diffhunk://#diff-444db9a0abe7244805030909aeb5ad505e3d766704264fae529096297be1cffdR1-R9) [[4]](diffhunk://#diff-5890b8d3edb9d2365d1e50c46779f8d8a8fccf01847fae4f714575da048dae81R1-R9)
