### PR TITLE
Enhance createSchema error message to include underlying error details

### DIFF
--- a/common/src/main/java/com/amazonaws/services/schemaregistry/common/AWSSchemaRegistryClient.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/common/AWSSchemaRegistryClient.java
@@ -250,7 +250,7 @@ public class AWSSchemaRegistryClient {
         } catch (Exception e) {
             String errorMessage = String.format(
                     "Create schema :: Call failed when creating the schema with the schema registry for"
-                    + " schema name = %s", schemaName);
+                    + " schema name = %s. Error = %s", schemaName, e.getMessage());
             throw new AWSSchemaRegistryException(errorMessage, e);
         }
 

--- a/common/src/test/java/com/amazonaws/services/schemaregistry/common/AWSSchemaRegistryClientTest.java
+++ b/common/src/test/java/com/amazonaws/services/schemaregistry/common/AWSSchemaRegistryClientTest.java
@@ -363,14 +363,17 @@ public class AWSSchemaRegistryClientTest {
                 .registryId(RegistryId.builder().registryName(glueSchemaRegistryConfiguration.getRegistryName()).build())
                 .build();
 
-        when(mockGlueClient.createSchema(createSchemaRequest)).thenThrow(EntityNotFoundException.class);
+        when(mockGlueClient.createSchema(createSchemaRequest))
+                .thenThrow(EntityNotFoundException.builder()
+                        .message("Schema registry entity not found")
+                        .build());
 
         try {
             awsSchemaRegistryClient.createSchema(schemaName, dataFormatName, userSchemaDefinition, getMetadata());
         } catch (Exception e) {
             assertEquals(EntityNotFoundException.class, e.getCause().getClass());
             assertEquals(AWSSchemaRegistryException.class, e.getClass());
-            String expectedErrorMessage = "Create schema :: Call failed when creating the schema with the schema registry for schema name = " + schemaName;
+            String expectedErrorMessage = "Create schema :: Call failed when creating the schema with the schema registry for schema name = " + schemaName + ". Error = Schema registry entity not found";
             assertEquals(expectedErrorMessage, e.getMessage());
         }
     }


### PR DESCRIPTION
*Issue #, if available:*
Enhance createSchema error message to include underlying error details

*Description of changes:*

- Add underlying exception message to createSchema error for better debugging
- Update error message format to include both schema name and root cause
- Update corresponding test to validate enhanced error message format

This improvement helps developers quickly identify the root cause of schema 
creation failures by including the actual underlying error details in the 
exception message along with the schema name context.

<img width="1532" height="503" alt="image" src="https://github.com/user-attachments/assets/b9f11e72-3331-4f69-ba2f-588aa77c0c7d" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
