### PR TITLE
Fixed duplicate children in parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@
         <module>kafkastreams-serde</module>
         <module>avro-kafkaconnect-converter</module>
         <module>avro-flink-serde</module>
-        <module>native-schema-registry</module>
         <module>examples</module>
         <module>integration-tests</module>
         <module>jsonschema-kafkaconnect-converter</module>


### PR DESCRIPTION
This pull request makes a small change to the project structure by removing the duplicate child `native-schema-registry` module from the build configuration in the parent `pom.xml`.