### PR TITLE
Upgrade aws sdk v2 to latest and add direct sts module dependency in native module [#421] + Remove redundant build profile from native pom [DO NOT SQUASH]

### DIFF
--- a/native-schema-registry/pom.xml
+++ b/native-schema-registry/pom.xml
@@ -144,41 +144,7 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>native-image</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.graalvm.nativeimage</groupId>
-                        <artifactId>native-image-maven-plugin</artifactId>
-                        <version>${graalvm.version}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>native-image</goal>
-                                </goals>
-                                <phase>package</phase>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <imageName>libnativeschemaregistry</imageName>
-                            <buildArgs combine.children="append">
-                                <buildArgs>
-                                    --verbose
-                                    --no-fallback
-                                    --shared
-                                    -g
-                                    -H:CLibraryPath=${project.basedir}/c/build/src
-                                    -H:ResourceConfigurationFiles=${project.basedir}/src/main/resources/resource-config.json
-                                    -H:Name=libnativeschemaregistry.so
-                                    --enable-url-protocols=http
-                                </buildArgs>
-                            </buildArgs>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+    <!-- glibc or musl would be selected explicitly going forward to avoid potential confusions -->
         <profile>
             <id>native-image-glibc</id>
             <build>


### PR DESCRIPTION
*Issue #, if available:*

[DO NOT SQUASH]

Upgrade aws sdk v2 to latest and add direct sts module dependency in native module ([#421](https://github.com/awslabs/aws-glue-schema-registry/issues/421))
Remove redundant build profile from native pom

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
