### PR TITLE
Adding musl build helper files

### DIFF
--- a/native-schema-registry/musl-build-helper-scripts/musl/Dockerfile
+++ b/native-schema-registry/musl-build-helper-scripts/musl/Dockerfile
@@ -1,0 +1,62 @@
+# ==========================
+# Stage 1 — Java build (GraalVM musl)
+# ==========================
+FROM ghcr.io/graalvm/native-image-community:17-muslib AS java-build
+
+WORKDIR /tmp
+
+# Build PIC-compatible zlib to fix shared library linking
+RUN curl -L https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.tar.gz | tar -xz && \
+    cd zlib-1.3 && \
+    CC=x86_64-linux-musl-gcc CFLAGS="-fPIC -O2" ./configure --static && \
+    make && \
+    cp libz.a /usr/local/musl/lib/libz.a
+
+
+# Install packages for Java build
+RUN microdnf install -y maven git unzip zip curl bash findutils ca-certificates tar gzip \
+ && microdnf clean all
+
+# Install packages for C build
+RUN microdnf install -y dnf dnf-plugins-core && \
+    dnf -y config-manager --set-enabled ol9_codeready_builder && \
+    dnf -y install oracle-epel-release-el9 && \
+    dnf -y --enablerepo=ol9_developer_EPEL install swig lcov gcc clang clang-tools-extra make cmake && \
+    dnf clean all && rm -rf /var/cache/dnf
+
+# Build core Java library
+RUN mvn -U clean install -Dcheckstyle.skip=true -DskipTests
+RUN pwd
+
+# TODO: remove this workaround when we have a straightforward way to build java first and then c
+# Build  C native libraries - just for java build to work as there is a dependency on c headers
+WORKDIR /tmp/native-schema-registry/c
+RUN cmake -S . -B build \
+  -DCMAKE_C_COMPILER=x86_64-linux-musl-gcc \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON 
+WORKDIR /tmp/native-schema-registry/c/build
+RUN cmake --build . || true
+
+# Build Java native-image profile
+WORKDIR /tmp/native-schema-registry
+RUN mvn clean install -P native-image-musl -DskipTests -Dcheckstyle.skip=true
+
+# ==========================
+# Stage 2 — Alpine latest (C + C# builds)
+# ==========================
+FROM alpine:latest
+
+WORKDIR /tmp
+COPY --from=java-build /tmp /tmp
+
+# Install dependencies for C and C#
+RUN apk add --no-cache \
+    bash git curl ca-certificates unzip zip findutils \
+    build-base cmake musl-dev clang clang-extra-tools llvm \
+    swig lcov protobuf protobuf-dev protoc \
+
+# --- C build ---
+WORKDIR /tmp/native-schema-registry/c
+RUN rm -rf build
+RUN cmake -S . -B build && cmake --build build
+

--- a/native-schema-registry/musl-build-helper-scripts/musl/Dockerfile.cmake
+++ b/native-schema-registry/musl-build-helper-scripts/musl/Dockerfile.cmake
@@ -1,0 +1,9 @@
+FROM  mcr.microsoft.com/dotnet/sdk:8.0-alpine
+
+
+RUN apk add \
+git curl ca-certificates unzip zip findutils \
+build-base cmake musl-dev clang clang-extra-tools llvm \
+swig lcov protobuf protobuf-dev protoc \
+
+

--- a/native-schema-registry/musl-build-helper-scripts/musl/Dockerfile.graalvm
+++ b/native-schema-registry/musl-build-helper-scripts/musl/Dockerfile.graalvm
@@ -1,0 +1,22 @@
+FROM ghcr.io/graalvm/native-image-community:17-muslib
+
+# Build PIC-compatible zlib to fix shared library linking
+
+
+# Install packages for Java build
+RUN microdnf install -y maven git unzip zip curl bash findutils ca-certificates tar gzip \
+ && microdnf clean all
+
+# Install packages for C build
+RUN microdnf install -y dnf dnf-plugins-core && \
+    dnf -y config-manager --set-enabled ol9_codeready_builder && \
+    dnf -y install oracle-epel-release-el9 && \
+    dnf -y --enablerepo=ol9_developer_EPEL install swig lcov gcc clang clang-tools-extra make cmake && \
+    dnf clean all && rm -rf /var/cache/dnf
+
+WORKDIR /tmp
+RUN curl -L https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.tar.gz | tar -xz && \
+    cd zlib-1.3 && \
+    CC=x86_64-linux-musl-gcc CFLAGS="-fPIC -O2" ./configure --static && \
+    make && \
+    cp libz.a /usr/local/musl/lib/libz.a

--- a/native-schema-registry/musl-build-helper-scripts/musl/build-musl.sh
+++ b/native-schema-registry/musl-build-helper-scripts/musl/build-musl.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Building native schema registry with musl..."
+
+docker build -f Dockerfile.graalvm -t native-graalvm .
+docker build -f Dockerfile.cmake -t native-cmake .
+# Get absolute path three levels up
+HOST_SOURCE_DIR="$(realpath ../../..)"
+SCRIPT_PATH="$(realpath ./build-musl-inner.sh)"
+CMAKE_SCRIPT_PATH="$(realpath ./build-musl-cmake.sh)"
+CONTAINER_WORKDIR="/workspace"
+IMAGE="ghcr.io/graalvm/native-image-community:17-muslib"
+
+docker run --rm -it \
+  --entrypoint /bin/sh \
+  -v "$HOST_SOURCE_DIR":"$CONTAINER_WORKDIR" \
+  -v "$SCRIPT_PATH":/tmp/musl-build-inner.sh \
+  -w "$CONTAINER_WORKDIR" \
+  "native-graalvm" \
+  /tmp/musl-build-inner.sh
+
+echo "Building cmake"
+docker run --rm -it \
+  -v "$HOST_SOURCE_DIR":"$CONTAINER_WORKDIR" \
+  -v "$CMAKE_SCRIPT_PATH":/tmp/musl-build-cmake.sh \
+  -w "$CONTAINER_WORKDIR" \
+  "native-cmake" \
+  /tmp/musl-build-cmake.sh


### PR DESCRIPTION
This pull request introduces a new multi-stage Docker build process for the native schema registry project, focusing on improved support for musl-based builds. The changes add new Dockerfiles for GraalVM and CMake environments, update build scripts to use these Dockerfiles, and enhance the installation of required dependencies for Java, C, and C# components. The overall goal is to streamline and modularize the build pipeline for musl compatibility.

**Build process improvements:**

* Added a multi-stage Docker build in `Dockerfile` to separate Java (GraalVM musl) and C/C# (Alpine) build environments, including explicit installation of dependencies and building of PIC-compatible zlib for shared library linking.
* Introduced new Dockerfiles: `Dockerfile.graalvm` for GraalVM-based Java builds and `Dockerfile.cmake` for CMake-based C/C# builds, each with tailored dependency installation for their respective environments. [[1]](diffhunk://#diff-6200d84666840ba2a099e9b9fa527f819ae0a10b81ec13f7c55011b2eca11764R1-R22) [[2]](diffhunk://#diff-030186aa582c353129d351c1a51b8d9c982f088f0922c87b2cead8a910c18908R1-R9)

**Build script updates:**

* Added `build-musl.sh` to automate building and running containers for both GraalVM and CMake environments, mounting source directories and invoking inner build scripts.

These changes collectively make the build process more modular, reproducible, and compatible with musl-based systems.