### PR TITLE
Adding avro happy path integration tests for schema evolution

### DIFF
--- a/native-schema-registry/shared/test/avro/backward/user_v1.avsc
+++ b/native-schema-registry/shared/test/avro/backward/user_v1.avsc
@@ -1,0 +1,11 @@
+{
+  "type": "record",
+  "name": "user_v1",
+  "doc": "Base schema for backward compatibility testing - COMPAT-007, COMPAT-010, COMPAT-011, COMPAT-012",
+  "fields": [
+    {"name": "id", "type": "string", "doc": "User identifier"},
+    {"name": "name", "type": "string", "doc": "User full name"},
+    {"name": "email", "type": "string", "doc": "User email address"},
+    {"name": "active", "type": "boolean", "default": true, "doc": "Account active status"}
+  ]
+}

--- a/native-schema-registry/shared/test/avro/backward/user_v2.avsc
+++ b/native-schema-registry/shared/test/avro/backward/user_v2.avsc
@@ -1,0 +1,11 @@
+{
+  "type": "record",
+  "name": "user_v2",
+  "doc": "Backward compatible evolution - removed 'email' field, added optional 'status' field with default",
+  "fields": [
+    {"name": "id", "type": "string", "doc": "User identifier"},
+    {"name": "name", "type": "string", "doc": "User full name"},
+    {"name": "active", "type": "boolean", "default": true, "doc": "Account active status"},
+    {"name": "status", "type": "string", "default": "registered", "doc": "User registration status"}
+  ]
+}

--- a/native-schema-registry/shared/test/avro/backward/user_v3.avsc
+++ b/native-schema-registry/shared/test/avro/backward/user_v3.avsc
@@ -1,0 +1,35 @@
+{
+  "type": "record",
+  "name": "user_v3",
+  "doc": "Third backward evolution - added optional 'age' field with default, demonstrates BACKWARD_ALL compatibility",
+  "fields": [
+    {
+      "name": "id",
+      "type": "string",
+      "doc": "User identifier"
+    },
+    {
+      "name": "name", 
+      "type": "string",
+      "doc": "User full name"
+    },
+    {
+      "name": "active",
+      "type": "boolean",
+      "default": true,
+      "doc": "Account active status"
+    },
+    {
+      "name": "status",
+      "type": "string", 
+      "default": "registered",
+      "doc": "User registration status"
+    },
+    {
+      "name": "age",
+      "type": "int",
+      "default": 0,
+      "doc": "User age"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/disabled/single.avsc
+++ b/native-schema-registry/shared/test/avro/disabled/single.avsc
@@ -1,0 +1,18 @@
+{
+  "type": "record",
+  "name": "single",
+  "doc": "Single schema for DISABLED compatibility testing - COMPAT-004, COMPAT-005, COMPAT-006. No versioning allowed after initial registration",
+  "fields": [
+    {
+      "name": "key",
+      "type": "string",
+      "doc": "Primary key field"
+    },
+    {
+      "name": "active",
+      "type": "boolean",
+      "default": true,
+      "doc": "Active status flag"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/forward/order_v1.avsc
+++ b/native-schema-registry/shared/test/avro/forward/order_v1.avsc
@@ -1,0 +1,29 @@
+{
+  "type": "record",
+  "name": "order_v1",
+  "doc": "Base schema for forward compatibility testing - COMPAT-013, COMPAT-016, COMPAT-017, COMPAT-018",
+  "fields": [
+    {
+      "name": "id",
+      "type": "string",
+      "doc": "Order identifier"
+    },
+    {
+      "name": "total",
+      "type": "int",
+      "doc": "Order total amount"
+    },
+    {
+      "name": "currency",
+      "type": "string",
+      "default": "USD",
+      "doc": "Currency code"
+    },
+    {
+      "name": "priority",
+      "type": "string",
+      "default": "normal",
+      "doc": "Order priority level"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/forward/order_v2.avsc
+++ b/native-schema-registry/shared/test/avro/forward/order_v2.avsc
@@ -1,0 +1,28 @@
+{
+  "type": "record",
+  "name": "order_v2",
+  "doc": "Forward compatible evolution - added 'status' field, removed optional 'priority' field",
+  "fields": [
+    {
+      "name": "id",
+      "type": "string",
+      "doc": "Order identifier"
+    },
+    {
+      "name": "total",
+      "type": "int",
+      "doc": "Order total amount"
+    },
+    {
+      "name": "currency",
+      "type": "string",
+      "default": "USD",
+      "doc": "Currency code"
+    },
+    {
+      "name": "status",
+      "type": "string",
+      "doc": "Order processing status"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/forward/order_v3.avsc
+++ b/native-schema-registry/shared/test/avro/forward/order_v3.avsc
@@ -1,0 +1,33 @@
+{
+  "type": "record",
+  "name": "order_v3",
+  "doc": "Third forward evolution - added 'timestamp' field, demonstrates FORWARD_ALL compatibility",
+  "fields": [
+    {
+      "name": "id",
+      "type": "string",
+      "doc": "Order identifier"
+    },
+    {
+      "name": "total",
+      "type": "int",
+      "doc": "Order total amount"
+    },
+    {
+      "name": "currency",
+      "type": "string",
+      "default": "USD",
+      "doc": "Currency code"
+    },
+    {
+      "name": "status",
+      "type": "string",
+      "doc": "Order processing status"
+    },
+    {
+      "name": "timestamp",
+      "type": "long",
+      "doc": "Order creation timestamp"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/full/profile_v1.avsc
+++ b/native-schema-registry/shared/test/avro/full/profile_v1.avsc
@@ -1,0 +1,24 @@
+{
+  "type": "record",
+  "name": "profile_v1",
+  "doc": "Base schema for full compatibility testing - COMPAT-019, COMPAT-020, COMPAT-021, COMPAT-022, COMPAT-023, COMPAT-024",
+  "fields": [
+    {
+      "name": "username",
+      "type": "string",
+      "doc": "Profile username"
+    },
+    {
+      "name": "verified",
+      "type": "boolean",
+      "default": false,
+      "doc": "Profile verification status"
+    },
+    {
+      "name": "theme",
+      "type": "string",
+      "default": "light",
+      "doc": "UI theme preference"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/full/profile_v2.avsc
+++ b/native-schema-registry/shared/test/avro/full/profile_v2.avsc
@@ -1,0 +1,24 @@
+{
+  "type": "record",
+  "name": "profile_v2",
+  "doc": "Full compatible evolution - only optional field changes with defaults (bidirectional compatibility)",
+  "fields": [
+    {
+      "name": "username",
+      "type": "string",
+      "doc": "Profile username"
+    },
+    {
+      "name": "verified",
+      "type": "boolean",
+      "default": false,
+      "doc": "Profile verification status"
+    },
+    {
+      "name": "notifications",
+      "type": "boolean",
+      "default": true,
+      "doc": "Notification preferences"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/none/test_v1.avsc
+++ b/native-schema-registry/shared/test/avro/none/test_v1.avsc
@@ -1,0 +1,17 @@
+{
+  "type": "record",
+  "name": "test_v1",
+  "doc": "Base schema for NONE compatibility testing - COMPAT-001, COMPAT-002, COMPAT-003",
+  "fields": [
+    {
+      "name": "data",
+      "type": "string",
+      "doc": "Test data field"
+    },
+    {
+      "name": "count",
+      "type": "int",
+      "doc": "Test count field"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/none/test_v2.avsc
+++ b/native-schema-registry/shared/test/avro/none/test_v2.avsc
@@ -1,0 +1,22 @@
+{
+  "type": "record",
+  "name": "test_v2",
+  "doc": "Incompatible evolution for NONE compatibility mode - completely different structure allowed",
+  "fields": [
+    {
+      "name": "message",
+      "type": "string",
+      "doc": "Message field"
+    },
+    {
+      "name": "enabled",
+      "type": "boolean",
+      "doc": "Enabled flag"
+    },
+    {
+      "name": "value",
+      "type": "string",
+      "doc": "String value field"
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds a comprehensive set of Avro schema files to support compatibility testing for the schema registry. The new files provide test cases for NONE, BACKWARD, FORWARD, FULL, and DISABLED compatibility modes, each illustrating typical schema evolution scenarios such as adding/removing fields, changing defaults, and bidirectional compatibility.

**Schema additions for compatibility testing:**

* **NONE compatibility mode:**
  - Added `test_v1.avsc` and `test_v2.avsc` to demonstrate unrestricted schema changes, including incompatible evolutions. [[1]](diffhunk://#diff-fe840b42a22ce5ab523decdaa4fbea00ea81b8ed4c2adbec3caab4847346c557R1-R17) [[2]](diffhunk://#diff-818182e554a49af024d736c55218d217f6bdbe28e2a304428775f6e0d74efba7R1-R22)

* **BACKWARD compatibility mode:**
  - Added `user_v1.avsc`, `user_v2.avsc`, and `user_v3.avsc` to show backward-compatible schema evolution, such as removing fields and adding optional fields with defaults. [[1]](diffhunk://#diff-904a933410f457a2379bb3769c358dde44a6fa7a327fcc9974a4a225ea9aec0dR1-R11) [[2]](diffhunk://#diff-7c515e8722db5d9afef809110fddccc81ad3a0a5022a14fff9de63c57ce94b71R1-R11) [[3]](diffhunk://#diff-ec0aa166b848b88bf2663c3f08dc66ad1350e7a39a0ebe5e23a9c37eca1cf6adR1-R35)

* **FORWARD compatibility mode:**
  - Added `order_v1.avsc`, `order_v2.avsc`, and `order_v3.avsc` to illustrate forward-compatible changes, including adding new fields and removing optional fields. [[1]](diffhunk://#diff-5c76d3ba201162c7014c65ec5d574e08a8331e88a6f042fe1ef68101b8d5c95dR1-R29) [[2]](diffhunk://#diff-957f78d71bd8cef2be996cd21ee84b238c818e8773abe23c78a6d770728c46b6R1-R28) [[3]](diffhunk://#diff-e885744512abcaffcb68048cf2f24a3e12008161cb524f6ed76bab3b6ecf32b4R1-R33)

* **FULL compatibility mode:**
  - Added `profile_v1.avsc` and `profile_v2.avsc` to demonstrate bidirectional compatibility with only optional field changes and defaults. [[1]](diffhunk://#diff-8e57271c176507afeeeaeb9d32e13c08e7f6d7437e94a10e4fb27550dfada35aR1-R24) [[2]](diffhunk://#diff-05a45783b33a2fb1598144cc32bcfc2318b964b7f9244c1af96848f607fd3ee1R1-R24)

* **DISABLED compatibility mode:**
  - Added `single.avsc` to show that no schema evolution is allowed after initial registration.