### PR TITLE
Added avro schemas for negative integration tests.

### DIFF
--- a/native-schema-registry/shared/test/avro/negative/backward/employee_v1.avsc
+++ b/native-schema-registry/shared/test/avro/negative/backward/employee_v1.avsc
@@ -1,0 +1,29 @@
+{
+  "type": "record",
+  "name": "Employee",
+  "namespace": "com.amazonaws.services.schemaregistry.test.backward.negative",
+  "doc": "Base schema for backward compatibility violation testing (COMPAT-028, COMPAT-031)",
+  "fields": [
+    {
+      "name": "id",
+      "type": "int",
+      "doc": "Employee ID"
+    },
+    {
+      "name": "firstName",
+      "type": "string",
+      "doc": "Employee first name"
+    },
+    {
+      "name": "lastName",
+      "type": "string",
+      "doc": "Employee last name"
+    },
+    {
+      "name": "department",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "Optional department"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/negative/backward/employee_v2.avsc
+++ b/native-schema-registry/shared/test/avro/negative/backward/employee_v2.avsc
@@ -1,0 +1,34 @@
+{
+  "type": "record",
+  "name": "Employee",
+  "namespace": "com.amazonaws.services.schemaregistry.test.backward.negative",
+  "doc": "Schema with required field addition - violates BACKWARD compatibility (COMPAT-028)",
+  "fields": [
+    {
+      "name": "id",
+      "type": "int",
+      "doc": "Employee ID"
+    },
+    {
+      "name": "firstName",
+      "type": "string",
+      "doc": "Employee first name"
+    },
+    {
+      "name": "lastName",
+      "type": "string",
+      "doc": "Employee last name"
+    },
+    {
+      "name": "department",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "Optional department"
+    },
+    {
+      "name": "requiredEmail",
+      "type": "string",
+      "doc": "Required email field - this addition breaks backward compatibility"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/negative/backward/employee_v3.avsc
+++ b/native-schema-registry/shared/test/avro/negative/backward/employee_v3.avsc
@@ -1,0 +1,33 @@
+{
+  "type": "record",
+  "name": "Employee",
+  "namespace": "com.amazonaws.services.schemaregistry.test.backward.negative",
+  "doc": "Schema that breaks compatibility with ANY previous version for BACKWARD_ALL testing (COMPAT-031)",
+  "fields": [
+    {
+      "name": "id",
+      "type": "int",
+      "doc": "Employee ID"
+    },
+    {
+      "name": "firstName",
+      "type": "string",
+      "doc": "Employee first name"
+    },
+    {
+      "name": "lastName",
+      "type": "string",
+      "doc": "Employee last name"
+    },
+    {
+      "name": "requiredSalary",
+      "type": "double",
+      "doc": "Required salary field - breaks compatibility with v1 (BACKWARD_ALL violation)"
+    },
+    {
+      "name": "requiredStartDate",
+      "type": "long",
+      "doc": "Required start date - another incompatible required addition"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/negative/disabled/restricted_v1.avsc
+++ b/native-schema-registry/shared/test/avro/negative/disabled/restricted_v1.avsc
@@ -1,0 +1,18 @@
+{
+  "type": "record",
+  "name": "RestrictedSchema",
+  "namespace": "com.amazonaws.services.schemaregistry.test.disabled",
+  "doc": "Base schema for DISABLED compatibility mode testing (COMPAT-025)",
+  "fields": [
+    {
+      "name": "id",
+      "type": "int",
+      "doc": "Unique identifier"
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "doc": "Entity name"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/negative/disabled/restricted_v2.avsc
+++ b/native-schema-registry/shared/test/avro/negative/disabled/restricted_v2.avsc
@@ -1,0 +1,23 @@
+{
+  "type": "record",
+  "name": "RestrictedSchema",
+  "namespace": "com.amazonaws.services.schemaregistry.test.disabled",
+  "doc": "Second version that should be rejected in DISABLED mode (COMPAT-025)",
+  "fields": [
+    {
+      "name": "id",
+      "type": "int",
+      "doc": "Unique identifier"
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "doc": "Entity name"
+    },
+    {
+      "name": "description",
+      "type": "string",
+      "doc": "Additional field that should cause rejection in DISABLED mode"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/negative/forward/product_v1.avsc
+++ b/native-schema-registry/shared/test/avro/negative/forward/product_v1.avsc
@@ -1,0 +1,34 @@
+{
+  "type": "record",
+  "name": "Product",
+  "namespace": "com.amazonaws.services.schemaregistry.test.forward.negative",
+  "doc": "Base schema for forward compatibility violation testing (COMPAT-034, COMPAT-037)",
+  "fields": [
+    {
+      "name": "id",
+      "type": "int",
+      "doc": "Product ID"
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "doc": "Product name"
+    },
+    {
+      "name": "price",
+      "type": "double",
+      "doc": "Product price"
+    },
+    {
+      "name": "category",
+      "type": "string",
+      "doc": "Product category - will be removed to break forward compatibility"
+    },
+    {
+      "name": "description",
+      "type": ["null", "string"],
+      "default": null,
+      "doc": "Optional product description"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/negative/forward/product_v2.avsc
+++ b/native-schema-registry/shared/test/avro/negative/forward/product_v2.avsc
@@ -1,0 +1,23 @@
+{
+  "type": "record",
+  "name": "Product",
+  "namespace": "com.amazonaws.services.schemaregistry.test.forward.negative",
+  "doc": "Schema with required field removal - violates FORWARD compatibility (COMPAT-034)",
+  "fields": [
+    {
+      "name": "id",
+      "type": "int",
+      "doc": "Product ID"
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "doc": "Product name"
+    },
+    {
+      "name": "price",
+      "type": "double",
+      "doc": "Product price"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/negative/forward/product_v3.avsc
+++ b/native-schema-registry/shared/test/avro/negative/forward/product_v3.avsc
@@ -1,0 +1,18 @@
+{
+  "type": "record",
+  "name": "Product",
+  "namespace": "com.amazonaws.services.schemaregistry.test.forward.negative",
+  "doc": "Schema incompatible with ANY previous version for FORWARD_ALL testing (COMPAT-037)",
+  "fields": [
+    {
+      "name": "productId",
+      "type": "string",
+      "doc": "Changed field type from int to string - breaks FORWARD_ALL compatibility"
+    },
+    {
+      "name": "displayName",
+      "type": "string",
+      "doc": "Renamed field from 'name' - incompatible change"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/negative/full/account_v1.avsc
+++ b/native-schema-registry/shared/test/avro/negative/full/account_v1.avsc
@@ -1,0 +1,36 @@
+{
+  "type": "record",
+  "name": "Account",
+  "namespace": "com.amazonaws.services.schemaregistry.test.full.negative",
+  "doc": "Base schema for FULL compatibility violation testing (COMPAT-040, COMPAT-043)",
+  "fields": [
+    {
+      "name": "accountId",
+      "type": "string",
+      "doc": "Account identifier"
+    },
+    {
+      "name": "balance",
+      "type": "double",
+      "doc": "Account balance"
+    },
+    {
+      "name": "status",
+      "type": {
+        "type": "enum",
+        "name": "AccountStatus",
+        "symbols": ["ACTIVE", "INACTIVE", "SUSPENDED"]
+      },
+      "doc": "Account status"
+    },
+    {
+      "name": "metadata",
+      "type": ["null", {
+        "type": "map",
+        "values": "string"
+      }],
+      "default": null,
+      "doc": "Optional metadata"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/negative/full/account_v2.avsc
+++ b/native-schema-registry/shared/test/avro/negative/full/account_v2.avsc
@@ -1,0 +1,41 @@
+{
+  "type": "record",
+  "name": "Account",
+  "namespace": "com.amazonaws.services.schemaregistry.test.full.negative",
+  "doc": "Schema v2 violates FULL compatibility by adding required field (COMPAT-040)",
+  "fields": [
+    {
+      "name": "accountId",
+      "type": "string",
+      "doc": "Account identifier"
+    },
+    {
+      "name": "balance",
+      "type": "double",
+      "doc": "Account balance"
+    },
+    {
+      "name": "status",
+      "type": {
+        "type": "enum",
+        "name": "AccountStatus",
+        "symbols": ["ACTIVE", "INACTIVE", "SUSPENDED"]
+      },
+      "doc": "Account status"
+    },
+    {
+      "name": "metadata",
+      "type": ["null", {
+        "type": "map",
+        "values": "string"
+      }],
+      "default": null,
+      "doc": "Optional metadata"
+    },
+    {
+      "name": "requiredNewField",
+      "type": "string",
+      "doc": "Required field addition violates FULL compatibility - not backward compatible"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/negative/full/account_v3.avsc
+++ b/native-schema-registry/shared/test/avro/negative/full/account_v3.avsc
@@ -1,0 +1,36 @@
+{
+  "type": "record",
+  "name": "Account", 
+  "namespace": "com.amazonaws.services.schemaregistry.test.full.negative",
+  "doc": "Schema v3 violates FULL compatibility by changing field type (COMPAT-043)",
+  "fields": [
+    {
+      "name": "accountId",
+      "type": "string",
+      "doc": "Account identifier"
+    },
+    {
+      "name": "balance",
+      "type": "int",
+      "doc": "Changed from double to int - violates FULL compatibility due to type change"
+    },
+    {
+      "name": "status",
+      "type": {
+        "type": "enum",
+        "name": "AccountStatus",
+        "symbols": ["ACTIVE", "INACTIVE", "SUSPENDED", "CLOSED"]
+      },
+      "doc": "Account status with added symbol - breaks forward compatibility"
+    },
+    {
+      "name": "metadata",
+      "type": ["null", {
+        "type": "map",
+        "values": "string"
+      }],
+      "default": null,
+      "doc": "Optional metadata"
+    }
+  ]
+}

--- a/native-schema-registry/shared/test/avro/negative/malformed/invalid_syntax.avsc
+++ b/native-schema-registry/shared/test/avro/negative/malformed/invalid_syntax.avsc
@@ -1,0 +1,12 @@
+{
+  "type": "record",
+  "name": "InvalidSchema",
+  "namespace": "com.amazonaws.services.schemaregistry.test"
+  "fields": [
+    {
+      "name": "field1",
+      "type": "string"
+    }
+  ]
+  // Missing comma after namespace - invalid JSON syntax
+}


### PR DESCRIPTION
This pull request adds several negative Avro schema test cases to verify compatibility violations across different compatibility modes (backward, forward, full, and disabled), as well as a malformed schema for syntax validation. These test schemas are designed to intentionally break compatibility rules and ensure the schema registry correctly rejects invalid changes.

**Compatibility violation test schemas:**

_Backward compatibility:_
* Added `employee_v1.avsc`, `employee_v2.avsc`, and `employee_v3.avsc` to test backward compatibility violations, including required field additions and changes that break compatibility with any previous version. [[1]](diffhunk://#diff-0b10127785ca71dd42e06eb5541225dd49ad49ca161aeec2f4208f257edad84cR1-R29) [[2]](diffhunk://#diff-4a4b79a7d544ed6e78a1f1e80ad9888df06436b3983d164f4b2d7644dcb6eb6dR1-R34) [[3]](diffhunk://#diff-7afccbf33e6c1adebdf2a137cdcab93822ae48392dbed2f6388ff92e863b9a49R1-R33)

_Forward compatibility:_
* Added `product_v1.avsc`, `product_v2.avsc`, and `product_v3.avsc` to test forward compatibility violations, such as required field removals and incompatible field type changes. [[1]](diffhunk://#diff-0abdd9c8c8833123cc8804c634cb1bf252e0e4c81de2f0b8c5081c1edaf894e2R1-R34) [[2]](diffhunk://#diff-bb878e395766c09b2830ba2bf5148b98d3321ee093063959db65aa5c74c7c349R1-R23) [[3]](diffhunk://#diff-4f53b37c0f1ce4609961782080d3537a6824eac51ea532fc74826af6ba795130R1-R18)

_Full compatibility:_
* Added `account_v1.avsc`, `account_v2.avsc`, and `account_v3.avsc` to test full compatibility violations, including required field additions and field type changes. [[1]](diffhunk://#diff-3110b8213e33d9386b76c734aa59ab10668d92c33945a74affaf7e7585597317R1-R36) [[2]](diffhunk://#diff-d4cf428a510a387ca252434e5dd180db2283f9e58b6a137301e686fc60ce51a3R1-R41) [[3]](diffhunk://#diff-a16ef10ac2d7dc0b9a6e1cb5ac5084538c01785ba7a676331e72999c3b3ac1a6R1-R36)

_Disabled compatibility mode:_
* Added `restricted_v1.avsc` and `restricted_v2.avsc` to verify schema registry behavior when compatibility checks are disabled, ensuring that certain changes are rejected. [[1]](diffhunk://#diff-9ca70be65ab4ce185ba6e605406475c5345f3eaddea3630bb2df8e0f34b69e6cR1-R18) [[2]](diffhunk://#diff-ea299bc123f4c3e8c74c476f9652ab44018bcb6669bc6c205d5193716040ec45R1-R23)

**Malformed schema:**

_Schema syntax validation:_
* Added `invalid_syntax.avsc`, a schema with invalid JSON syntax to test handling of malformed schema definitions.