### PR TITLE
Fix getCtype errors with Protobuf parsing

### DIFF
--- a/avro-flink-serde/pom.xml
+++ b/avro-flink-serde/pom.xml
@@ -28,6 +28,12 @@
     </description>
     <url>https://aws.amazon.com/glue</url>
     <packaging>jar</packaging>
+    <parent>
+        <groupId>software.amazon.glue</groupId>
+        <artifactId>schema-registry-parent</artifactId>
+        <version>1.1.25</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
     <developers>
         <developer>
@@ -66,7 +72,7 @@
         <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-serde</artifactId>
-    <version>1.1.25</version>
+            <version>1.1.25</version>
         </dependency>
         <dependency>
           <groupId>org.projectlombok</groupId>
@@ -205,7 +211,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                <source>8</source>
+                    <source>8</source>
                 </configuration>
                 <executions>
                     <execution>

--- a/common/src/test/java/com/amazonaws/services/schemaregistry/common/SchemaByDefinitionFetcherTest.java
+++ b/common/src/test/java/com/amazonaws/services/schemaregistry/common/SchemaByDefinitionFetcherTest.java
@@ -193,7 +193,7 @@ public class SchemaByDefinitionFetcherTest {
         assertTrue(
             exception.getMessage().contains("Exception occurred while fetching or registering schema definition"));
         assertTrue(
-            exception.getMessage().contains("Error: Unknown"));
+            exception.getMessage().contains("Error: java.lang.RuntimeException: Unknown"));
     }
 
     @Test

--- a/native-schema-registry/PROTOBUF_REFLECTION.md
+++ b/native-schema-registry/PROTOBUF_REFLECTION.md
@@ -1,0 +1,59 @@
+# Protocol Buffers Reflection Configuration
+
+This document explains how to resolve Protocol Buffers reflection issues in GraalVM native image compilation.
+
+## Problem
+
+GraalVM native image compilation fails with `NoSuchMethodException` for Protocol Buffers methods like:
+- `getCtype()`
+- `valueOf()`
+- `hasExtension()`
+
+These errors occur because Protocol Buffers uses reflection for field options and enum value lookups that aren't automatically detected by GraalVM.
+
+## Solution
+
+Use the GraalVM tracing agent to automatically discover reflection requirements:
+
+```bash
+./scripts/trace-protobuf-reflection.sh
+```
+
+This script:
+1. Creates a test that exercises Protocol Buffers reflection paths
+2. Runs the test with GraalVM tracing agent
+3. Generates comprehensive reflection configuration
+4. Saves the configuration for review and integration
+
+## Manual Configuration
+
+If automatic tracing isn't sufficient, manually add these classes to `reflect-config.json`:
+
+```json
+{
+  "name": "com.google.protobuf.DescriptorProtos$FieldOptions",
+  "methods": [
+    {"name": "getCtype", "parameterTypes": []},
+    {"name": "hasCtype", "parameterTypes": []},
+    {"name": "getJstype", "parameterTypes": []},
+    {"name": "hasJstype", "parameterTypes": []}
+  ]
+},
+{
+  "name": "com.google.protobuf.DescriptorProtos$FieldOptions$CType",
+  "methods": [
+    {"name": "valueOf", "parameterTypes": ["com.google.protobuf.Descriptors$EnumValueDescriptor"]}
+  ]
+}
+```
+
+## Key Classes
+
+The following Protocol Buffers classes commonly need reflection configuration:
+
+- `DescriptorProtos$FieldOptions` - Field option getters/setters
+- `DescriptorProtos$FieldOptions$CType` - Field type enums
+- `DescriptorProtos$FieldOptions$JSType` - JavaScript type enums
+- `DescriptorProtos$FeatureSet` - Protocol Buffers features
+- `sun.misc.Unsafe` - Low-level memory operations
+

--- a/native-schema-registry/golang/Makefile
+++ b/native-schema-registry/golang/Makefile
@@ -125,6 +125,8 @@ generate-protos: setup-dirs
 			fi; \
 		fi; \
 	done
+	@echo "Generating integration test protobuf files..."
+	@/usr/local/bin/protoc --proto_path=integration-tests --go_out=integration-tests/testpb --go_opt=paths=source_relative integration-tests/test_message.proto
 	@echo "Protobuf generation complete"
 
 # Allow overriding variables for custom proto generation

--- a/native-schema-registry/pom.xml
+++ b/native-schema-registry/pom.xml
@@ -74,10 +74,22 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.api.grpc</groupId>
+            <artifactId>proto-google-common-protos</artifactId>
+            <version>2.25.1</version>
+        </dependency>
+
+        <dependency>
             <!-- TODO: Revisit logging -->
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+
 
         <dependency>
             <!-- TODO: Revisit logging -->
@@ -96,6 +108,13 @@
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
             <version>${graalvm.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -119,6 +138,18 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
             <!-- Disable checkstyle for native-schema-registry module -->
             <plugin>

--- a/native-schema-registry/scripts/trace-protobuf-reflection.sh
+++ b/native-schema-registry/scripts/trace-protobuf-reflection.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# AI Generated
+# TODO: We should make this part of build process
+
+# GraalVM Tracing Agent for Protocol Buffers Reflection Discovery
+# This script helps discover reflection requirements for Protocol Buffers classes
+# that cause NoSuchMethodException during native image compilation.
+#
+
+
+set -e
+
+JAVA_HOME=${GRAALVM_HOME:-$JAVA_HOME}
+CONFIG_DIR="src/main/resources/META-INF/native-image/software.amazon.glue/native-schema-registry"
+TEMP_CONFIG_DIR="temp-protobuf-config"
+
+echo "Protocol Buffers Reflection Tracing Agent"
+echo "========================================="
+
+# Clean up
+rm -rf $TEMP_CONFIG_DIR
+mkdir -p $TEMP_CONFIG_DIR
+
+# Get classpath from Maven
+echo "Resolving classpath from Maven..."
+MAVEN_CLASSPATH=$(cd .. && mvn dependency:build-classpath -q -Dmdep.outputFile=/dev/stdout | tail -1)
+
+if [ -z "$MAVEN_CLASSPATH" ]; then
+    echo "❌ Failed to resolve classpath from Maven"
+    echo "Run: mvn dependency:resolve"
+    exit 1
+fi
+
+CLASSPATH=".:$MAVEN_CLASSPATH"
+echo "✅ Classpath resolved from pom.xml dependencies"
+
+# Write classpath to file to avoid "Argument list too long" error
+echo "$CLASSPATH" > classpath.txt
+
+# Create test that triggers Protocol Buffers reflection
+cat > TestProtobufReflection.java << 'EOF'
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Descriptors;
+import com.amazonaws.services.schemaregistry.utils.apicurio.FileDescriptorUtils;
+
+public class TestProtobufReflection {
+    public static void main(String[] args) {
+        try {
+            System.out.println("Testing Protocol Buffers reflection paths...");
+            
+            // Create FileDescriptor with field options that trigger hasExtension calls
+            DescriptorProtos.FileDescriptorProto.Builder fileBuilder = 
+                DescriptorProtos.FileDescriptorProto.newBuilder();
+            fileBuilder.setName("test.proto");
+            fileBuilder.setPackage("test");
+            
+            DescriptorProtos.DescriptorProto.Builder messageBuilder = 
+                DescriptorProtos.DescriptorProto.newBuilder();
+            messageBuilder.setName("TestMessage");
+            
+            DescriptorProtos.FieldDescriptorProto.Builder fieldBuilder = 
+                DescriptorProtos.FieldDescriptorProto.newBuilder();
+            fieldBuilder.setName("test_field");
+            fieldBuilder.setNumber(1);
+            fieldBuilder.setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING);
+            
+            // Add field options that trigger reflection
+            DescriptorProtos.FieldOptions.Builder optionsBuilder = 
+                DescriptorProtos.FieldOptions.newBuilder();
+            optionsBuilder.setCtype(DescriptorProtos.FieldOptions.CType.STRING);
+            optionsBuilder.setJstype(DescriptorProtos.FieldOptions.JSType.JS_STRING);
+            
+            fieldBuilder.setOptions(optionsBuilder.build());
+            messageBuilder.addField(fieldBuilder.build());
+            fileBuilder.addMessageType(messageBuilder.build());
+            
+            DescriptorProtos.FileDescriptorProto fileProto = fileBuilder.build();
+            
+            // Trigger FileDescriptorUtils processing that uses hasExtension
+            var protoFile = FileDescriptorUtils.fileDescriptorToProtoFile(fileProto);
+            System.out.println("✅ FileDescriptorUtils processing completed: " + protoFile.getPackageName());
+            
+            System.out.println("✅ Protocol Buffers reflection test completed successfully!");
+            
+        } catch (Exception e) {
+            System.err.println("❌ Error during Protocol Buffers reflection test:");
+            e.printStackTrace();
+        }
+    }
+}
+EOF
+
+echo "Compiling Protocol Buffers reflection test..."
+$JAVA_HOME/bin/javac -cp @classpath.txt TestProtobufReflection.java
+
+echo "Running with GraalVM tracing agent..."
+$JAVA_HOME/bin/java \
+  -agentlib:native-image-agent=config-output-dir=$TEMP_CONFIG_DIR \
+  -cp @classpath.txt \
+  TestProtobufReflection
+
+if [ -f "$TEMP_CONFIG_DIR/reflect-config.json" ]; then
+    echo ""
+    echo "Generated Protocol Buffers reflection config:"
+    echo "============================================="
+    cat $TEMP_CONFIG_DIR/reflect-config.json | jq '.' 2>/dev/null || cat $TEMP_CONFIG_DIR/reflect-config.json
+    echo "============================================="
+    
+    # Save discovered config
+    mkdir -p $CONFIG_DIR
+    cp $TEMP_CONFIG_DIR/reflect-config.json $CONFIG_DIR/reflect-config-discovered.json
+    echo ""
+    echo "✅ Saved discovered config to: $CONFIG_DIR/reflect-config-discovered.json"
+    echo ""
+    echo "To use this configuration:"
+    echo "1. Review the discovered classes and methods"
+    echo "2. Merge with existing reflect-config.json if needed"
+    echo "3. Test native image compilation: ./buildall"
+else
+    echo "❌ No reflection config was generated"
+fi
+
+# Cleanup
+rm -f TestProtobufReflection.java TestProtobufReflection.class classpath.txt
+rm -rf $TEMP_CONFIG_DIR
+
+echo ""
+echo "Protocol Buffers reflection tracing completed!"

--- a/native-schema-registry/src/main/resources/META-INF/native-image/software.amazon.glue/native-schema-registry/reflect-config.json
+++ b/native-schema-registry/src/main/resources/META-INF/native-image/software.amazon.glue/native-schema-registry/reflect-config.json
@@ -1,0 +1,57 @@
+[
+{
+  "name":"com.google.protobuf.DescriptorProtos$FeatureSet",
+  "methods":[{"name":"newBuilder","parameterTypes":[] }]
+},
+{
+  "name":"com.google.protobuf.DescriptorProtos$FieldOptions",
+  "methods":[{"name":"getCtype","parameterTypes":[] }, {"name":"getDebugRedact","parameterTypes":[] }, {"name":"getDeprecated","parameterTypes":[] }, {"name":"getEditionDefaults","parameterTypes":["int"] }, {"name":"getEditionDefaultsCount","parameterTypes":[] }, {"name":"getEditionDefaultsList","parameterTypes":[] }, {"name":"getFeatures","parameterTypes":[] }, {"name":"getJstype","parameterTypes":[] }, {"name":"getLazy","parameterTypes":[] }, {"name":"getPacked","parameterTypes":[] }, {"name":"getRetention","parameterTypes":[] }, {"name":"getTargets","parameterTypes":["int"] }, {"name":"getTargetsCount","parameterTypes":[] }, {"name":"getTargetsList","parameterTypes":[] }, {"name":"getUninterpretedOption","parameterTypes":["int"] }, {"name":"getUninterpretedOptionCount","parameterTypes":[] }, {"name":"getUninterpretedOptionList","parameterTypes":[] }, {"name":"getUnverifiedLazy","parameterTypes":[] }, {"name":"getWeak","parameterTypes":[] }, {"name":"hasCtype","parameterTypes":[] }, {"name":"hasDebugRedact","parameterTypes":[] }, {"name":"hasDeprecated","parameterTypes":[] }, {"name":"hasFeatures","parameterTypes":[] }, {"name":"hasJstype","parameterTypes":[] }, {"name":"hasLazy","parameterTypes":[] }, {"name":"hasPacked","parameterTypes":[] }, {"name":"hasRetention","parameterTypes":[] }, {"name":"hasUnverifiedLazy","parameterTypes":[] }, {"name":"hasWeak","parameterTypes":[] }]
+},
+{
+  "name":"com.google.protobuf.DescriptorProtos$FieldOptions$Builder",
+  "methods":[{"name":"addEditionDefaults","parameterTypes":["com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault"] }, {"name":"addTargets","parameterTypes":["com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType"] }, {"name":"addUninterpretedOption","parameterTypes":["com.google.protobuf.DescriptorProtos$UninterpretedOption"] }, {"name":"clearCtype","parameterTypes":[] }, {"name":"clearDebugRedact","parameterTypes":[] }, {"name":"clearDeprecated","parameterTypes":[] }, {"name":"clearEditionDefaults","parameterTypes":[] }, {"name":"clearFeatures","parameterTypes":[] }, {"name":"clearJstype","parameterTypes":[] }, {"name":"clearLazy","parameterTypes":[] }, {"name":"clearPacked","parameterTypes":[] }, {"name":"clearRetention","parameterTypes":[] }, {"name":"clearTargets","parameterTypes":[] }, {"name":"clearUninterpretedOption","parameterTypes":[] }, {"name":"clearUnverifiedLazy","parameterTypes":[] }, {"name":"clearWeak","parameterTypes":[] }, {"name":"getCtype","parameterTypes":[] }, {"name":"getDebugRedact","parameterTypes":[] }, {"name":"getDeprecated","parameterTypes":[] }, {"name":"getEditionDefaults","parameterTypes":["int"] }, {"name":"getEditionDefaultsBuilder","parameterTypes":["int"] }, {"name":"getEditionDefaultsCount","parameterTypes":[] }, {"name":"getEditionDefaultsList","parameterTypes":[] }, {"name":"getFeatures","parameterTypes":[] }, {"name":"getFeaturesBuilder","parameterTypes":[] }, {"name":"getJstype","parameterTypes":[] }, {"name":"getLazy","parameterTypes":[] }, {"name":"getPacked","parameterTypes":[] }, {"name":"getRetention","parameterTypes":[] }, {"name":"getTargets","parameterTypes":["int"] }, {"name":"getTargetsCount","parameterTypes":[] }, {"name":"getTargetsList","parameterTypes":[] }, {"name":"getUninterpretedOption","parameterTypes":["int"] }, {"name":"getUninterpretedOptionBuilder","parameterTypes":["int"] }, {"name":"getUninterpretedOptionCount","parameterTypes":[] }, {"name":"getUninterpretedOptionList","parameterTypes":[] }, {"name":"getUnverifiedLazy","parameterTypes":[] }, {"name":"getWeak","parameterTypes":[] }, {"name":"hasCtype","parameterTypes":[] }, {"name":"hasDebugRedact","parameterTypes":[] }, {"name":"hasDeprecated","parameterTypes":[] }, {"name":"hasFeatures","parameterTypes":[] }, {"name":"hasJstype","parameterTypes":[] }, {"name":"hasLazy","parameterTypes":[] }, {"name":"hasPacked","parameterTypes":[] }, {"name":"hasRetention","parameterTypes":[] }, {"name":"hasUnverifiedLazy","parameterTypes":[] }, {"name":"hasWeak","parameterTypes":[] }, {"name":"setCtype","parameterTypes":["com.google.protobuf.DescriptorProtos$FieldOptions$CType"] }, {"name":"setDebugRedact","parameterTypes":["boolean"] }, {"name":"setDeprecated","parameterTypes":["boolean"] }, {"name":"setEditionDefaults","parameterTypes":["int","com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault"] }, {"name":"setFeatures","parameterTypes":["com.google.protobuf.DescriptorProtos$FeatureSet"] }, {"name":"setJstype","parameterTypes":["com.google.protobuf.DescriptorProtos$FieldOptions$JSType"] }, {"name":"setLazy","parameterTypes":["boolean"] }, {"name":"setPacked","parameterTypes":["boolean"] }, {"name":"setRetention","parameterTypes":["com.google.protobuf.DescriptorProtos$FieldOptions$OptionRetention"] }, {"name":"setTargets","parameterTypes":["int","com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType"] }, {"name":"setUninterpretedOption","parameterTypes":["int","com.google.protobuf.DescriptorProtos$UninterpretedOption"] }, {"name":"setUnverifiedLazy","parameterTypes":["boolean"] }, {"name":"setWeak","parameterTypes":["boolean"] }]
+},
+{
+  "name":"com.google.protobuf.DescriptorProtos$FieldOptions$CType",
+  "methods":[{"name":"getValueDescriptor","parameterTypes":[] }, {"name":"valueOf","parameterTypes":["com.google.protobuf.Descriptors$EnumValueDescriptor"] }]
+},
+{
+  "name":"com.google.protobuf.DescriptorProtos$FieldOptions$EditionDefault",
+  "methods":[{"name":"newBuilder","parameterTypes":[] }]
+},
+{
+  "name":"com.google.protobuf.DescriptorProtos$FieldOptions$JSType",
+  "methods":[{"name":"getValueDescriptor","parameterTypes":[] }, {"name":"valueOf","parameterTypes":["com.google.protobuf.Descriptors$EnumValueDescriptor"] }]
+},
+{
+  "name":"com.google.protobuf.DescriptorProtos$FieldOptions$OptionRetention",
+  "methods":[{"name":"getValueDescriptor","parameterTypes":[] }, {"name":"valueOf","parameterTypes":["com.google.protobuf.Descriptors$EnumValueDescriptor"] }]
+},
+{
+  "name":"com.google.protobuf.DescriptorProtos$FieldOptions$OptionTargetType",
+  "methods":[{"name":"getValueDescriptor","parameterTypes":[] }, {"name":"valueOf","parameterTypes":["com.google.protobuf.Descriptors$EnumValueDescriptor"] }]
+},
+{
+  "name":"com.google.protobuf.DescriptorProtos$UninterpretedOption",
+  "methods":[{"name":"newBuilder","parameterTypes":[] }]
+},
+{
+  "name":"com.google.protobuf.ExtensionRegistry",
+  "methods":[{"name":"getEmptyRegistry","parameterTypes":[] }]
+},
+{
+  "name":"java.nio.Buffer",
+  "fields":[{"name":"address"}]
+},
+{
+  "name":"libcore.io.Memory"
+},
+{
+  "name":"org.robolectric.Robolectric"
+},
+{
+  "name":"sun.misc.Unsafe",
+  "allDeclaredFields":true,
+  "methods":[{"name":"arrayBaseOffset","parameterTypes":["java.lang.Class"] }, {"name":"arrayIndexScale","parameterTypes":["java.lang.Class"] }, {"name":"copyMemory","parameterTypes":["long","long","long"] }, {"name":"copyMemory","parameterTypes":["java.lang.Object","long","java.lang.Object","long","long"] }, {"name":"getBoolean","parameterTypes":["java.lang.Object","long"] }, {"name":"getByte","parameterTypes":["long"] }, {"name":"getByte","parameterTypes":["java.lang.Object","long"] }, {"name":"getDouble","parameterTypes":["java.lang.Object","long"] }, {"name":"getFloat","parameterTypes":["java.lang.Object","long"] }, {"name":"getInt","parameterTypes":["long"] }, {"name":"getInt","parameterTypes":["java.lang.Object","long"] }, {"name":"getLong","parameterTypes":["long"] }, {"name":"getLong","parameterTypes":["java.lang.Object","long"] }, {"name":"getObject","parameterTypes":["java.lang.Object","long"] }, {"name":"objectFieldOffset","parameterTypes":["java.lang.reflect.Field"] }, {"name":"putBoolean","parameterTypes":["java.lang.Object","long","boolean"] }, {"name":"putByte","parameterTypes":["long","byte"] }, {"name":"putByte","parameterTypes":["java.lang.Object","long","byte"] }, {"name":"putDouble","parameterTypes":["java.lang.Object","long","double"] }, {"name":"putFloat","parameterTypes":["java.lang.Object","long","float"] }, {"name":"putInt","parameterTypes":["long","int"] }, {"name":"putInt","parameterTypes":["java.lang.Object","long","int"] }, {"name":"putLong","parameterTypes":["long","long"] }, {"name":"putLong","parameterTypes":["java.lang.Object","long","long"] }, {"name":"putObject","parameterTypes":["java.lang.Object","long","java.lang.Object"] }]
+}
+]

--- a/native-schema-registry/src/main/resources/resource-config.json
+++ b/native-schema-registry/src/main/resources/resource-config.json
@@ -3,6 +3,15 @@
     "includes": [
       {
         "pattern": ".*/.*proto$"
+      },
+      {
+        "pattern": "google/.*\\.proto$"
+      },
+      {
+        "pattern": "google/protobuf/.*\\.proto$"
+      },
+      {
+        "pattern": "\\.proto$"
       }
     ]
   }

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,6 @@
         <module>integration-tests</module>
         <module>jsonschema-kafkaconnect-converter</module>
         <module>protobuf-kafkaconnect-converter</module>
-        <module>native-schema-registry</module>
     </modules>
 
     <properties>

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/apicurio/ProtobufSchemaLoader.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/apicurio/ProtobufSchemaLoader.java
@@ -73,11 +73,24 @@ public class ProtobufSchemaLoader {
     //as Square doesn't support them by default.
     private final static Set<String> GOOGLE_WELLKNOWN_PROTOS =
         ImmutableSet.<String>builder()
+            .add("any.proto")
             .add("api.proto")
+            .add("descriptor.proto")
+            .add("duration.proto")
+            .add("empty.proto")
             .add("field_mask.proto")
             .add("source_context.proto")
             .add("struct.proto")
+            .add("timestamp.proto")
             .add("type.proto")
+            .add("wrappers.proto")
+            .build();
+
+    //Adding support for Wire library protobuf extensions
+    private static final String WIRE_PATH = "wire/";
+    private final static Set<String> WIRE_PROTOS =
+        ImmutableSet.<String>builder()
+            .add("extensions.proto")
             .build();
 
     private final static String METADATA_PROTO = "metadata.proto";
@@ -96,6 +109,9 @@ public class ProtobufSchemaLoader {
         createDirectory(GOOGLE_WELLKNOWN_PATH.split("/"), inMemoryFileSystem);
         loadProtoFiles(inMemoryFileSystem, classLoader, GOOGLE_WELLKNOWN_PROTOS, GOOGLE_WELLKNOWN_PATH);
 
+        createDirectory(WIRE_PATH.split("/"), inMemoryFileSystem);
+        loadProtoFiles(inMemoryFileSystem, classLoader, WIRE_PROTOS, WIRE_PATH);
+
         createDirectory(METADATA_PATH.split("/"), inMemoryFileSystem);
         loadProtoFiles(inMemoryFileSystem, classLoader, Collections.singleton(METADATA_PROTO), METADATA_PATH);
 
@@ -112,6 +128,9 @@ public class ProtobufSchemaLoader {
         for (String proto : protos) {
             //Loads the proto file resource files.
             final InputStream inputStream = classLoader.getResourceAsStream(protoPath + proto);
+            if (inputStream == null) {
+                throw new IOException("Proto file not found: " + protoPath + proto);
+            }
             final String fileContents = CharStreams.toString(new InputStreamReader(inputStream, Charsets.UTF_8));
             final Path dir = Path.get("/").resolve(protoPath);
             inMemoryFileSystem.createDirectories(dir);


### PR DESCRIPTION
*Issue #, if available:*

Fix the getCtype errors happening during Protobuf parsing. Also fixes failing tests.

*Description of changes:*
1. Introduces a reflection config that guides graalVM to load classes correctly.
2. Fixes Protobuf parsing logic due to missing boilerplate .protos
3. Adds a script that uses GraalVM tracing agent to identify classes to add to reflection config.

*Testing*

All integration tests pass

```
2025-09-06 03:35:51:718 +0000 [main] INFO com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration - avroRecordType key is not present in the configs
2025-09-06 03:35:51:720 +0000 [main] INFO com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration - protobufMessageType key is not present in the configs
2025-09-06 03:35:51:720 +0000 [main] INFO com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration - compression key is not present in the configs
2025-09-06 03:35:51:720 +0000 [main] INFO com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration - jacksonSerializationFeatures key is not present in the configs
2025-09-06 03:35:51:720 +0000 [main] INFO com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration - jacksonDeserializationFeatures key is not present in the configs
2025-09-06 03:35:51:720 +0000 [main] INFO com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration - tags key is not present in the configs
2025-09-06 03:35:51:720 +0000 [main] INFO com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration - Tags value is not defined in the properties. No tags are assigned
2025-09-06 03:35:51:720 +0000 [main] INFO com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration - metadata key is not present in the configs
2025-09-06 03:35:51:720 +0000 [main] INFO com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration - userAgentApp key is not present in the configs
2025-09-06 03:35:51:720 +0000 [main] INFO com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration - secondaryDeserializer key is not present in the configs
2025-09-06 03:35:51:720 +0000 [main] INFO com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration - proxyUrl key is not present in the configs
2025-09-06 03:35:51:720 +0000 [main] INFO com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration - cacheSize key is not present in the configs
2025-09-06 03:35:51:720 +0000 [main] INFO com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration - Cache Size is not found, using default 200
2025-09-06 03:35:51:720 +0000 [main] INFO com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration - timeToLiveMillis key is not present in the configs
2025-09-06 03:35:51:720 +0000 [main] INFO com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration - Cache Time to live is not found, using default 86400000
2025-09-06 03:35:51:722 +0000 [main] WARN software.amazon.awssdk.profiles.internal.ProfileFileReader - Ignoring earlier-seen '[default]', because '[profile default]' was found on line 95
2025-09-06 03:35:51:725 +0000 [main] WARN software.amazon.awssdk.profiles.internal.ProfileFileReader - Ignoring earlier-seen '[default]', because '[profile default]' was found on line 95
2025-09-06 03:35:51:727 +0000 [main] WARN software.amazon.awssdk.profiles.internal.ProfileFileReader - Ignoring earlier-seen '[default]', because '[profile default]' was found on line 95
    sarama_integration_suite_test.go:101: Deserializing GSR-encoded data
2025-09-06 03:35:51:741 +0000 [main] WARN software.amazon.awssdk.profiles.internal.ProfileFileReader - Ignoring earlier-seen '[default]', because '[profile default]' was found on line 95
2025-09-06 03:35:51:744 +0000 [main] WARN software.amazon.awssdk.profiles.internal.ProfileFileReader - Ignoring earlier-seen '[default]', because '[profile default]' was found on line 95
2025-09-06 03:35:51:744 +0000 [main] DEBUG software.amazon.awssdk.request - Sending Request: DefaultSdkHttpFullRequest(httpMethod=POST, protocol=https, host=glue.us-east-1.amazonaws.com, encodedPath=/, headers=[amz-sdk-invocation-id, Content-Length, Content-Type, User-Agent, X-Amz-Target], queryParameters=[])
2025-09-06 03:35:52:004 +0000 [main] DEBUG software.amazon.awssdk.request - Received successful response: 200, Request ID: 736a8e58-136e-4ed4-bfef-2c879912ecc4, Extended Request ID: not available
    sarama_integration_suite_test.go:107: Validating round-trip
    sarama_integration_suite_test.go:194: Original: id:"sarama-test-789"  name:"Sarama Integration Test"  age:28  email:"sarama@example.com"  tags:"integration"  tags:"test"  tags:"sarama"  tags:"protobuf"  tags:"gsr"  tags:"pure-go"
    sarama_integration_suite_test.go:195: Deserialized (after conversion): id:"sarama-test-789"  name:"Sarama Integration Test"  age:28  email:"sarama@example.com"  tags:"integration"  tags:"test"  tags:"sarama"  tags:"protobuf"  tags:"gsr"  tags:"pure-go"
    sarama_integration_suite_test.go:204: ✅ Sarama protobuf message validation passed
    sarama_integration_suite_test.go:110: ✅ Sarama integration test passed for *testpb.TestMessage
    sarama_integration_suite_test.go:63: --- Sarama Protobuf Integration Test Complete ---
    base_integration_suite.go:57: Starting test teardown...
    base_integration_suite.go:61: ✓ Cleared serializer/deserializer references
    base_integration_suite.go:300: Deleted Kafka topic: -golang-integration-test-suite-d5931e13
    base_integration_suite.go:69: Test teardown complete
--- PASS: TestSaramaIntegrationSuite (11.65s)
    --- PASS: TestSaramaIntegrationSuite/TestSaramaProtobufIntegration (11.65s)
PASS
ok      github.com/awslabs/aws-glue-schema-registry/native-schema-registry/golang/integration-tests     112.251s
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
