### PR TITLE
Make consumer worker parallely work by offering a generic middleware interface of the deserializer

### DIFF
--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/KafkaFlowSerDeMiddleware/GlueSchemaRegistryKafkaFlowProtobufDeserializeMiddleware.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/KafkaFlowSerDeMiddleware/GlueSchemaRegistryKafkaFlowProtobufDeserializeMiddleware.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AWSGsrSerDe.deserializer;
+using AWSGsrSerDe.common;
+using Google.Protobuf;
+using KafkaFlow;
+
+namespace AWSGsrSerDe.KafkaFlow
+{
+    /// <summary>
+    /// KafkaFlow middleware that DESERIALIZES byte[] -> T using AWS Glue SR.
+    /// Register it with MiddlewareLifetime.Worker for one instance per worker.
+    /// </summary>
+    public sealed class GlueSchemaRegistryKafkaFlowProtobufDeserializeMiddleware<T> : IMessageMiddleware
+        where T : class, IMessage<T>, new()
+    {
+        private readonly GlueSchemaRegistryKafkaDeserializer _gsr;
+
+        public GlueSchemaRegistryKafkaFlowProtobufDeserializeMiddleware(string configPath)
+        {
+            try
+            {
+                var dataConfig = new GlueSchemaRegistryDataFormatConfiguration(new Dictionary<string, dynamic>
+                {
+                    { GlueSchemaRegistryConstants.ProtobufMessageDescriptor, new T().Descriptor }
+                });
+
+                _gsr = new GlueSchemaRegistryKafkaDeserializer(configPath, dataConfig);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to initialize GlueSchemaRegistry deserializer for {typeof(T).Name}: {ex.Message}", ex);
+            }
+        }
+
+        public async Task Invoke(IMessageContext context, MiddlewareDelegate next)
+        {
+            if (context is null) throw new ArgumentNullException(nameof(context));
+
+            // Expect raw bytes coming from Kafka
+            if (context.Message.Value is not byte[] payload)
+                throw new InvalidOperationException(
+                    $"Expected byte[] payload before deserialization, got {context.Message.Value?.GetType().FullName ?? "null"}");
+
+            // Topic to assist SR lookup / subject resolution
+            var topic = context.ConsumerContext?.Topic
+                        ?? throw new InvalidOperationException("Topic not available in ConsumerContext");
+
+            T value;
+            try
+            {
+                // Use the deserializer to get the typed object
+                value = (T)_gsr.Deserialize(topic, payload);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to deserialize {typeof(T).Name} from topic '{topic}': {ex.Message}", ex);
+            }
+
+            // Create a new message with the deserialized value and continue to next middleware
+            var transformedContext = context.SetMessage(context.Message.Key, value);
+
+            await next(transformedContext);
+        }
+    }
+}

--- a/native-schema-registry/demos/csharp/Consumer/Program.cs
+++ b/native-schema-registry/demos/csharp/Consumer/Program.cs
@@ -91,11 +91,14 @@ class Program
                             .Topic("users")
                             .WithGroupId("user-consumer-group")
                             .WithBufferSize(100)
-                            .WithWorkersCount(1)
+                            .WithWorkersCount(10)
                             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
                             .AddMiddlewares(middlewares => middlewares
                                 .Add<ExceptionMiddleware>()
-                                .AddDeserializer(resolver => new GlueSchemaRegistryKafkaFlowProtobufDeserializer<User>(CONFIG_PATH))
+                                .Add(
+                                resolver => new GlueSchemaRegistryKafkaFlowProtobufDeserializeMiddleware<User>(CONFIG_PATH),
+                                MiddlewareLifetime.Worker
+                            )
                                 .AddTypedHandlers(h => h.AddHandler<UserHandler>())
                             )
                         )
@@ -103,11 +106,14 @@ class Program
                             .Topic("products")
                             .WithGroupId("product-consumer-group")
                             .WithBufferSize(100)
-                            .WithWorkersCount(1)
+                            .WithWorkersCount(10)
                             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
                             .AddMiddlewares(middlewares => middlewares
                                 .Add<ExceptionMiddleware>() 
-                                .AddDeserializer(resolver => new GlueSchemaRegistryKafkaFlowProtobufDeserializer<Product>(CONFIG_PATH))
+                                .Add(
+                                resolver => new GlueSchemaRegistryKafkaFlowProtobufDeserializeMiddleware<Product>(CONFIG_PATH),
+                                MiddlewareLifetime.Worker
+                            )
                                 .AddTypedHandlers(h => h.AddHandler<ProductHandler>())
                             )
                         )
@@ -115,11 +121,14 @@ class Program
                             .Topic("orders")
                             .WithGroupId("order-consumer-group")
                             .WithBufferSize(100)
-                            .WithWorkersCount(1)
+                            .WithWorkersCount(10)
                             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
                             .AddMiddlewares(middlewares => middlewares
                                 .Add<ExceptionMiddleware>()
-                                .AddDeserializer(resolver => new GlueSchemaRegistryKafkaFlowProtobufDeserializer<Order>(CONFIG_PATH))
+                                .Add(
+                                resolver => new GlueSchemaRegistryKafkaFlowProtobufDeserializeMiddleware<Order>(CONFIG_PATH),
+                                MiddlewareLifetime.Worker
+                            )
                                 .AddTypedHandlers(h => h.AddHandler<OrderHandler>())
                             )
                         )
@@ -127,11 +136,14 @@ class Program
                             .Topic("payments")
                             .WithGroupId("payment-consumer-group")
                             .WithBufferSize(100)
-                            .WithWorkersCount(1)
+                            .WithWorkersCount(10)
                             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
                             .AddMiddlewares(middlewares => middlewares
                                 .Add<ExceptionMiddleware>()
-                                .AddDeserializer(resolver => new GlueSchemaRegistryKafkaFlowProtobufDeserializer<Payment>(CONFIG_PATH))
+                                .Add(
+                                resolver => new GlueSchemaRegistryKafkaFlowProtobufDeserializeMiddleware<Payment>(CONFIG_PATH),
+                                MiddlewareLifetime.Worker
+                            )
                                 .AddTypedHandlers(h => h.AddHandler<PaymentHandler>())
                             )
                         )
@@ -139,12 +151,15 @@ class Program
                             .Topic("events")
                             .WithGroupId("event-consumer-group")
                             .WithBufferSize(100)
-                            .WithWorkersCount(1)
+                            .WithWorkersCount(10)
                             .WithAutoOffsetReset(AutoOffsetReset.Earliest)
                             .AddMiddlewares(middlewares => middlewares 
-                                .Add<ExceptionMiddleware>()
-                                .AddDeserializer(resolver => new GlueSchemaRegistryKafkaFlowProtobufDeserializer<Event>(CONFIG_PATH))
-                                .AddTypedHandlers(h => h.AddHandler<EventHandler>())
+                            .Add<ExceptionMiddleware>()
+                            .Add(
+                                resolver => new GlueSchemaRegistryKafkaFlowProtobufDeserializeMiddleware<Event>(CONFIG_PATH),
+                                MiddlewareLifetime.Worker
+                            )
+                            .AddTypedHandlers(h => h.AddHandler<EventHandler>())
                             )
                         )
                     )

--- a/native-schema-registry/demos/csharp/Producer/Program.cs
+++ b/native-schema-registry/demos/csharp/Producer/Program.cs
@@ -116,7 +116,7 @@ class Program
     {
         var producer = host.Services.GetRequiredService<IProducerAccessor>().GetProducer("user-producer");
         
-        for (int counter = 1; counter <= 10 && !_shutdown; counter++)
+        for (int counter = 1; counter <= 1000 && !_shutdown; counter++)
         {
             try
             {
@@ -130,12 +130,9 @@ class Program
 
                 producer.Produce(user.Id, user);
                 
-                lock (_lock)
-                {
-                    Console.WriteLine($"[UserProducer] Sent: {user.Name} ({user})");
-                }
+                Console.WriteLine($"[UserProducer] Sent: {user.Name} ({user})");
                 
-                Thread.Sleep(1000);
+                
             }
             catch (Exception ex)
             {
@@ -153,7 +150,7 @@ class Program
     {
         var producer = host.Services.GetRequiredService<IProducerAccessor>().GetProducer("product-producer");
         
-        for (int counter = 1; counter <= 10 && !_shutdown; counter++)
+        for (int counter = 1; counter <= 1000 && !_shutdown; counter++)
         {
             try
             {
@@ -168,12 +165,9 @@ class Program
 
                 producer.Produce(product.Sku, product);
                 
-                lock (_lock)
-                {
-                    Console.WriteLine($"[ProductProducer] Sent: {product.Name} (${product})");
-                }
+                Console.WriteLine($"[ProductProducer] Sent: {product.Name} (${product})");
                 
-                Thread.Sleep(1200);
+                
             }
             catch (Exception ex)
             {
@@ -191,7 +185,7 @@ class Program
     {
         var producer = host.Services.GetRequiredService<IProducerAccessor>().GetProducer("order-producer");
         
-        for (int counter = 1; counter <= 10 && !_shutdown; counter++)
+        for (int counter = 1; counter <= 1000 && !_shutdown; counter++)
         {
             try
             {
@@ -231,12 +225,8 @@ class Program
 
                 producer.Produce(order.OrderId, order);
                 
-                lock (_lock)
-                {
-                    Console.WriteLine($"[OrderProducer] Sent: Order {order.OrderId} (${order.Header})");
-                }
+                Console.WriteLine($"[OrderProducer] Sent: Order {order.OrderId} (${order.Header})");
                 
-                Thread.Sleep(1500);
             }
             catch (Exception ex)
             {
@@ -254,7 +244,7 @@ class Program
     {
         var producer = host.Services.GetRequiredService<IProducerAccessor>().GetProducer("payment-producer");
         
-        for (int counter = 1; counter <= 10 && !_shutdown; counter++)
+        for (int counter = 1; counter <= 1000 && !_shutdown; counter++)
         {
             try
             {
@@ -299,12 +289,9 @@ class Program
 
                 producer.Produce(payment.PaymentId, payment);
                 
-                lock (_lock)
-                {
-                    Console.WriteLine($"[PaymentProducer] Sent: Payment {payment.PaymentId} (${payment})");
-                }
+                Console.WriteLine($"[PaymentProducer] Sent: Payment {payment.PaymentId} (${payment})");
                 
-                Thread.Sleep(1800);
+                
             }
             catch (Exception ex)
             {
@@ -322,7 +309,7 @@ class Program
     {
         var producer = host.Services.GetRequiredService<IProducerAccessor>().GetProducer("event-producer");
         
-        for (int counter = 1; counter <= 10 && !_shutdown; counter++)
+        for (int counter = 1; counter <= 1000 && !_shutdown; counter++)
         {
             try
             {
@@ -369,12 +356,8 @@ class Program
 
                 producer.Produce(eventMsg.EventId, eventMsg);
                 
-                lock (_lock)
-                {
-                    Console.WriteLine($"[EventProducer] Sent: Event {eventMsg.EventId} ({eventMsg})");
-                }
+                Console.WriteLine($"[EventProducer] Sent: Event {eventMsg.EventId} ({eventMsg})");
                 
-                Thread.Sleep(800);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
*Issue #, if available:*
Make consumer worker parallely work by offering a generic middleware interface of the deserializer


*Description of changes:*
Make consumer worker parallely work by offering a generic middleware interface of the deserializer

## Test evidence:

### 1000 messages each of 5 DataTypes - events, orders, users, payments and procuts are parsed by deserializer correctly from kafka.
<img width="763" height="503" alt="image" src="https://github.com/user-attachments/assets/1ec0e766-48c6-42df-9be5-9e31b36fa6ac" />

### Distribution of messages evenly across 3 partitions:

<img width="660" height="288" alt="image" src="https://github.com/user-attachments/assets/4e3d0a54-5e7d-4e05-97e8-c3b49565b6d2" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
