### PR TITLE
GraalVM-17-to-21-update

### DIFF
--- a/native-schema-registry/README.md
+++ b/native-schema-registry/README.md
@@ -10,7 +10,7 @@ Change `/native-schema-registry/src/main/java/com/amazonaws/services/schemaregis
 
 ## Build command for multi-lang GSR
 mvn install -P native-image
-Note: If you get any issues due to JAVA_HOME not found, just set it to graalvm java 17 installation path.
+Note: If you get any issues due to JAVA_HOME not found, just set it to graalvm java 21 installation path.
 
 
 Usually, the process is as follows:
@@ -23,7 +23,7 @@ On Amazon Linux, you might need to install cmake, Python, lcov, llvm etc and set
 
 The versions we've used when building the native schema registry library are:
 - Maven 3.8.7
-- Java (GraalVM) 17.0.12
+- Java (GraalVM Community Edition) 21.0.2
 - gcov 13.3.0
 - llvm 18.1.3
 - lcov 2.0-1

--- a/native-schema-registry/musl-build-helper-scripts/musl/Dockerfile
+++ b/native-schema-registry/musl-build-helper-scripts/musl/Dockerfile
@@ -1,7 +1,7 @@
 # ==========================
 # Stage 1 — Java build (GraalVM musl)
 # ==========================
-FROM ghcr.io/graalvm/native-image-community:17-muslib AS java-build
+FROM ghcr.io/graalvm/native-image-community:21-muslib AS java-build
 
 WORKDIR /tmp
 

--- a/native-schema-registry/musl-build-helper-scripts/musl/Dockerfile.graalvm
+++ b/native-schema-registry/musl-build-helper-scripts/musl/Dockerfile.graalvm
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image-community:17-muslib
+FROM ghcr.io/graalvm/native-image-community:21-muslib
 
 # Build PIC-compatible zlib to fix shared library linking
 

--- a/native-schema-registry/musl-build-helper-scripts/musl/build-musl.sh
+++ b/native-schema-registry/musl-build-helper-scripts/musl/build-musl.sh
@@ -10,7 +10,7 @@ HOST_SOURCE_DIR="$(realpath ../../..)"
 SCRIPT_PATH="$(realpath ./build-musl-inner.sh)"
 CMAKE_SCRIPT_PATH="$(realpath ./build-musl-cmake.sh)"
 CONTAINER_WORKDIR="/workspace"
-IMAGE="ghcr.io/graalvm/native-image-community:17-muslib"
+IMAGE="ghcr.io/graalvm/native-image-community:21-muslib"
 
 docker run --rm -it \
   --entrypoint /bin/sh \


### PR DESCRIPTION
Updating readme's and musl build scripts to reference building with graalvm-ce-21 instead of 17.