### PR TITLE
Onboard git-secrets to check for unintended passwords, access keys or tokens added as a part of PRs

### DIFF
--- a/.github/workflows/build-csharp.yml
+++ b/.github/workflows/build-csharp.yml
@@ -31,7 +31,6 @@ jobs:
           git secrets --install
 
           # Add custom patterns
-          git secrets --add 'password\s*=\s*.+'
           git secrets --add 'api[_-]?key\s*=\s*.+'
           git secrets --add 'secret[_-]?key\s*=\s*.+'
           git secrets --add 'token\s*=\s*.+'

--- a/.github/workflows/build-csharp.yml
+++ b/.github/workflows/build-csharp.yml
@@ -2,14 +2,54 @@ name: Build CSharp
 
 on:
   push:
-    branches: [ master, native-schema-registry-2025, native-schema-registry-csharp, native-schema-registry-golang ]
+    branches: [ master, native-schema-registry-release ]
   pull_request:
-    branches: [ master, native-schema-registry-2025, native-schema-registry-csharp, native-schema-registry-golang ]
+    branches: [ master, native-schema-registry-release ]
   release:
-    branches: [ master, native-schema-registry-2025, native-schema-registry-csharp, native-schema-registry-golang ]
+    branches: [ master, native-schema-registry-release ]
     types: [ created ]
 
 jobs:
+  git-secrets-scan:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install git-secrets
+        run: |
+          git clone https://github.com/awslabs/git-secrets.git
+          cd git-secrets
+          sudo make install
+
+      - name: Configure git-secrets
+        run: |
+          git secrets --register-aws
+          git secrets --install
+
+          # Add custom patterns
+          git secrets --add 'password\s*=\s*.+'
+          git secrets --add 'api[_-]?key\s*=\s*.+'
+          git secrets --add 'secret[_-]?key\s*=\s*.+'
+          git secrets --add 'token\s*=\s*.+'
+
+          # Enhanced AWS credential patterns
+          git secrets --add 'AWS_ACCESS_KEY_ID\s*=\s*[A-Z0-9]{20}'
+          git secrets --add 'AWS_SECRET_ACCESS_KEY\s*=\s*[A-Za-z0-9/+=]{40}'
+          git secrets --add 'AWS_SESSION_TOKEN\s*=\s*[A-Za-z0-9/+=]+'
+          git secrets --add 'AWS_SECURITY_TOKEN\s*=\s*[A-Za-z0-9/+=]+'
+          
+          # AWS Account and ARN patterns
+          git secrets --add 'AWS_ACCOUNT_ID\s*=\s*[0-9]{12}'
+
+      - name: Scan repository
+        run: |
+          git secrets --scan-history
+          git secrets --scan
+
   build-csharp:
     continue-on-error: false
     timeout-minutes: 60


### PR DESCRIPTION
## Issue #, if available:

Currently, there are no checks when contributing to the project on whether tokens, secrets or passwords are added unintentionally in the code/configs.



## Description of changes:
This PR onboards `git-secrets` job to the git workflow to check for unintended passwords, access keys or tokens added as a part of PRs so that contributors are made aware and can avoid committing these into the repo.

-----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
