### PR TITLE
Swap vulnerable dependency versions of various Csharp libraries with their latest versions

### DIFF
--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/AWSGsrSerDe.Tests.csproj
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/AWSGsrSerDe.Tests.csproj
@@ -8,13 +8,13 @@
 
     <ItemGroup>
         <PackageReference Include="Google.Api.CommonProtos" Version="2.6.0" />
-        <PackageReference Include="Google.Protobuf" Version="3.21.4" />
+        <PackageReference Include="Google.Protobuf" Version="3.32.1" />
         <PackageReference Include="Grpc.Tools" Version="2.48.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="KafkaFlow" Version="3.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.9" />
         <PackageReference Include="NJsonSchema" Version="10.8.0" />
         <PackageReference Include="NUnit" Version="3.12.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
@@ -25,7 +25,7 @@
         </PackageReference>
         <AdditionalFiles Include="stylecop.json" />
         <PackageReference Include="System.Runtime.Caching" Version="6.0.0" />
-        <PackageReference Include="System.Text.Json" Version="6.0.6" />
+        <PackageReference Include="System.Text.Json" Version="9.0.9" />
     </ItemGroup>
 
     <ItemGroup>

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/AWSGsrSerDe.csproj
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/AWSGsrSerDe.csproj
@@ -19,10 +19,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Apache.Avro" Version="1.11.0" />
-      <PackageReference Include="Google.Protobuf" Version="3.21.4" />
+      <PackageReference Include="Apache.Avro" Version="1.12.0" />
+      <PackageReference Include="Google.Protobuf" Version="3.32.1" />
       <PackageReference Include="KafkaFlow" Version="3.0.10" />
-      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.9" />
       <PackageReference Include="NJsonSchema" Version="10.8.0" />
       <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
         <PrivateAssets>all</PrivateAssets>
@@ -30,7 +30,7 @@
       </PackageReference>
       <AdditionalFiles Include="stylecop.json" />
       <PackageReference Include="System.Runtime.Caching" Version="6.0.0" />
-      <PackageReference Include="System.Text.Json" Version="6.0.6" />
+      <PackageReference Include="System.Text.Json" Version="9.0.9" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
# Issue #, if available:
Currently, there are certain Csharp dependencies that have CVEs discovered in their current versions as they are in the library.

# Description of changes:
This PR upgrades from the CVE-prone dependency versions to their latest versions.

## Upgraded dependencies 

### __Main Project (AWSGsrSerDe.csproj):__

- __Apache.Avro__: `1.11.0` → `1.12.0` *(CRITICAL - fixes 3 CVEs)*
- __Google.Protobuf__: `3.21.4` → `3.32.1` *(HIGH - fixes 1 CVE)*
- __Microsoft.Extensions.Caching.Memory__: `6.0.1` → `9.0.9` *(HIGH - fixes 1 CVE)*
- __System.Text.Json__: `6.0.6` → `9.0.9` *(HIGH - fixes 1 CVE)*

### __Test Project (AWSGsrSerDe.Tests.csproj):__

- __Google.Protobuf__: `3.21.4` → `3.32.1` *(HIGH - fixes 1 CVE)*
- __Microsoft.Extensions.Caching.Memory__: `6.0.1` → `9.0.9` *(HIGH - fixes 1 CVE)*
- __System.Text.Json__: `6.0.6` → `9.0.9` *(HIGH - fixes 1 CVE)*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
