### PR TITLE
[DRAFT] Add a null check for the lower level (de)serializer in ReleaseUnmanagedResources method during dispose flow of C# SerDe objects

### DIFF
--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/GlueSchemaRegistrySerDeTests.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/GlueSchemaRegistrySerDeTests.cs
@@ -208,7 +208,7 @@ namespace AWSGsrSerDe.Tests
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             finalize?.Invoke(serializer, null);
             
-            Assert.Pass("Constructor failure handled gracefully");
+            Assert.Pass("Disposal failure handled gracefully");
         }
 
         /// <summary>
@@ -228,7 +228,7 @@ namespace AWSGsrSerDe.Tests
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             finalize?.Invoke(deserializer, null);
             
-            Assert.Pass("Deserializer finalizer handled disposal without issues");
+            Assert.Pass("Disposal failure handled gracefully");
         }
 
         private static GenericRecord GetTestAvroRecord()

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/GlueSchemaRegistrySerDeTests.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/GlueSchemaRegistrySerDeTests.cs
@@ -191,6 +191,46 @@ namespace AWSGsrSerDe.Tests
 //              }
 //          }
 
+        /// <summary>
+        /// Test Serializer disposal when the object is uninitialized but finalizer still runs
+        /// This is not the exact usage scenario but simulates the case when unknown garbage collection race condition
+        /// causes the finalizer to run when the serializer object is null
+        /// </summary>
+        [Test]
+        public void SerializerConstructorDoubleFinalizerTest()
+        {
+            // Create uninitialized object to simulate failed constructor leaving _serializer null
+            var serializer = (GlueSchemaRegistrySerializer)System.Runtime.Serialization.FormatterServices
+                .GetUninitializedObject(typeof(GlueSchemaRegistrySerializer));
+            
+            // Manually trigger finalizer on this uninitialized object
+            var finalize = typeof(GlueSchemaRegistrySerializer).GetMethod("Finalize", 
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            finalize?.Invoke(serializer, null);
+            
+            Assert.Pass("Constructor failure handled gracefully");
+        }
+
+        /// <summary>
+        /// Test Deserializer disposal when the object is uninitialized but finalizer still runs
+        /// This is not the exact usage scenario but simulates the case when unknown garbage collection race condition
+        /// causes the finalizer to run when the deserializer object is null
+        /// </summary>
+        [Test]
+        public void DeserializerConstructorDoubleFinalizerTest()
+        {
+            // Create uninitialized object to simulate failed constructor leaving _deserializer null
+            var deserializer = (GlueSchemaRegistryDeserializer)System.Runtime.Serialization.FormatterServices
+                .GetUninitializedObject(typeof(GlueSchemaRegistryDeserializer));
+            
+            // Manually trigger finalizer on this uninitialized object
+            var finalize = typeof(GlueSchemaRegistryDeserializer).GetMethod("Finalize", 
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            finalize?.Invoke(deserializer, null);
+            
+            Assert.Pass("Deserializer finalizer handled disposal without issues");
+        }
+
         private static GenericRecord GetTestAvroRecord()
         {
             var recordSchema = Schema.Parse(TestAvroSchema);

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/GlueSchemaRegistryDeserializer.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/GlueSchemaRegistryDeserializer.cs
@@ -144,7 +144,7 @@ namespace AWSGsrSerDe
 
         private void ReleaseUnmanagedResources()
         {
-            _deserializer.Dispose();
+            _deserializer?.Dispose();
         }
 
         private void Dispose(bool disposing)

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/GlueSchemaRegistrySerializer.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/GlueSchemaRegistrySerializer.cs
@@ -114,7 +114,7 @@ namespace AWSGsrSerDe
 
         private void ReleaseUnmanagedResources()
         {
-            _serializer.Dispose();
+            _serializer?.Dispose();
         }
 
         private void Dispose(bool disposing)


### PR DESCRIPTION
Add a null check for the lower level (de)serializer in ReleaseUnmanagedResources method during dispose flow of C# SerDe objects

## Issue #, if available:
Right now, the `Dispose` methods in `GlueSchemaRegistryDeserializer` and `GlueSchemaRegistrySerializer` which are called during Finalize flow (triggered by GC) is not thread safe. 

## Description of changes:

We are handling a specific exception during the dispose flow (*NullReferenceException*) by checking if the lower-level serializer or deserializer object is null.

## Before the null-check
<img width="1109" height="333" alt="image" src="https://github.com/user-attachments/assets/9a2d36c5-3fe0-4f0c-8e1a-18bade03ce9e" />

<img width="2244" height="690" alt="image" src="https://github.com/user-attachments/assets/14f1737e-f0c7-4e05-b3d7-a656448f6b88" />


## After the null-check
<img width="460" height="117" alt="image" src="https://github.com/user-attachments/assets/1da87092-d155-41d0-abd1-9df0694c44fa" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
