### PR TITLE
Upgarde csharp library version to OneOneTwentyFive to match java base we are using + Make demo producers multi-threaded

### DIFF
--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/AWSGsrSerDe.csproj
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/AWSGsrSerDe.csproj
@@ -5,7 +5,7 @@
         <CodeAnalysisRuleSet>GlueSchemaRegistry.ruleset</CodeAnalysisRuleSet>
          <PackageId>AWSGsrSerDe</PackageId>
          <!-- Matching with java layer version -->
-          <Version>1.1.10</Version>
+          <Version>1.1.25</Version>
           <Company>Amazon</Company>
           <Product>AWS Glue Schema Registry CSharp SerDe</Product>
           <Description>AWS Glue Schema Registry serializers/deserializers for .NET (Avro/JSON/Protobuf).</Description>

--- a/native-schema-registry/csharp/AWSGsrSerDe/README.md
+++ b/native-schema-registry/csharp/AWSGsrSerDe/README.md
@@ -27,7 +27,7 @@ After the build steps are successful, do the following:
 dotnet pack -c Release --no-build
 ```
 
-This outputs: ./bin/Release/AWSGsrSerDe.1.1.10.nupkg
+This outputs: ./bin/Release/AWSGsrSerDe.1.1.25.nupkg
 
 #### Running C# tests
 

--- a/native-schema-registry/demos/csharp/Consumer/Consumer.csproj
+++ b/native-schema-registry/demos/csharp/Consumer/Consumer.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>ProtobufGSRKafkaDemo.Consumer</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AWSGsrSerDeVersion>1.1.10</AWSGsrSerDeVersion>
+    <AWSGsrSerDeVersion>1.1.25</AWSGsrSerDeVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/native-schema-registry/demos/csharp/Producer/Producer.csproj
+++ b/native-schema-registry/demos/csharp/Producer/Producer.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>ProtobufGSRKafkaDemo.Producer</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AWSGsrSerDeVersion>1.1.10</AWSGsrSerDeVersion>
+    <AWSGsrSerDeVersion>1.1.25</AWSGsrSerDeVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/native-schema-registry/demos/csharp/Shared/Shared.csproj
+++ b/native-schema-registry/demos/csharp/Shared/Shared.csproj
@@ -5,11 +5,11 @@
     <RootNamespace>ProtobufGSRKafkaDemo</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AWSGsrSerDeVersion>1.1.10</AWSGsrSerDeVersion>
+    <AWSGsrSerDeVersion>1.1.25</AWSGsrSerDeVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.25.1" />
+    <PackageReference Include="Google.Protobuf" Version="3.32.1" />
     <PackageReference Include="Grpc.Tools" Version="2.59.0" PrivateAssets="All" />
     <PackageReference Include="KafkaFlow" Version="3.0.10" />
   </ItemGroup>


### PR DESCRIPTION
# Issue #, if available:
1. The csharp library is versioned @ 1.1.10 which lost parity with Java base.
2. The producers in the demo use only one thread and therefore are not production-like examples.

# Description of changes:
1. This PR restores that parity of versioning in c layer and java base
2. Add multi-threaded producers making it production-like.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
