### PR TITLE
Refactor Go package: consolidate CGO flags and rename package

### DIFF
--- a/native-schema-registry/golang/pkg/gsrserde-go/cgo_flags.go
+++ b/native-schema-registry/golang/pkg/gsrserde-go/cgo_flags.go
@@ -1,4 +1,4 @@
-package GsrSerDe
+package gsrserde
 
 /*
 #cgo CFLAGS: -w

--- a/native-schema-registry/golang/pkg/gsrserde-go/deserializer.go
+++ b/native-schema-registry/golang/pkg/gsrserde-go/deserializer.go
@@ -7,10 +7,6 @@ import (
 )
 
 /*
-#cgo CFLAGS: -w
-#cgo CFLAGS: -I../../lib/include
-#cgo LDFLAGS: -Wl,-rpath,${SRCDIR}/../../lib
-#cgo LDFLAGS: -L../../lib -lnativeschemaregistry -lnative_schema_registry_c -lnative_schema_registry_c_data_types -laws_common_memalloc
 #include "../../lib/include/glue_schema_registry_deserializer.h"
 #include "../../lib/include/glue_schema_registry_error.h"
 */

--- a/native-schema-registry/golang/pkg/gsrserde-go/errors.go
+++ b/native-schema-registry/golang/pkg/gsrserde-go/errors.go
@@ -7,10 +7,6 @@ import (
 )
 
 /*
-#cgo CFLAGS: -w
-#cgo CFLAGS: -I../../lib/include
-#cgo LDFLAGS: -Wl,-rpath,${SRCDIR}/../../lib
-#cgo LDFLAGS: -L../../lib -lnativeschemaregistry -lnative_schema_registry_c -lnative_schema_registry_c_data_types -laws_common_memalloc
 #include "../../lib/include/glue_schema_registry_error.h"
 #include <stdlib.h>
 #include <string.h>

--- a/native-schema-registry/golang/pkg/gsrserde-go/helpers.go
+++ b/native-schema-registry/golang/pkg/gsrserde-go/helpers.go
@@ -5,10 +5,6 @@ import (
 )
 
 /*
-#cgo CFLAGS: -w
-#cgo CFLAGS: -I../../lib/include
-#cgo LDFLAGS: -Wl,-rpath,${SRCDIR}/../../lib
-#cgo LDFLAGS: -L../../lib -lnativeschemaregistry -lnative_schema_registry_c -lnative_schema_registry_c_data_types -laws_common_memalloc
 #include "../../lib/include/read_only_byte_array.h"
 #include "../../lib/include/mutable_byte_array.h"
 #include "../../lib/include/glue_schema_registry_schema.h"

--- a/native-schema-registry/golang/pkg/gsrserde-go/schema.go
+++ b/native-schema-registry/golang/pkg/gsrserde-go/schema.go
@@ -5,10 +5,6 @@ import (
 )
 
 /*
-#cgo CFLAGS: -w
-#cgo CFLAGS: -I../../lib/include
-#cgo LDFLAGS: -Wl,-rpath,${SRCDIR}/../../lib
-#cgo LDFLAGS: -L../../lib -lnativeschemaregistry -lnative_schema_registry_c -lnative_schema_registry_c_data_types -laws_common_memalloc
 #include "../../lib/include/glue_schema_registry_schema.h"
 #include "../../lib/include/glue_schema_registry_error.h"
 #include <stdlib.h>

--- a/native-schema-registry/golang/pkg/gsrserde-go/serializer.go
+++ b/native-schema-registry/golang/pkg/gsrserde-go/serializer.go
@@ -6,10 +6,6 @@ import (
 )
 
 /*
-#cgo CFLAGS: -w
-#cgo CFLAGS: -I../../lib/include
-#cgo LDFLAGS: -Wl,-rpath,${SRCDIR}/../../lib
-#cgo LDFLAGS: -L../../lib -lnativeschemaregistry -lnative_schema_registry_c -lnative_schema_registry_c_data_types -laws_common_memalloc
 #include "../../lib/include/glue_schema_registry_serializer.h"
 #include "../../lib/include/glue_schema_registry_error.h"
 #include "../../lib/include/mutable_byte_array.h"


### PR DESCRIPTION
- Move cgo_flags.go from GsrSerDe to gsrserde-go package
- Remove duplicate CGO directives from individual files
- Centralize CGO configuration in single cgo_flags.go file
- Update package name from GsrSerDe to gsrserde for consistency
