### PR TITLE
Add user_agent parameter to schema registry serializer/deserializer c…

### DIFF
--- a/native-schema-registry/c/include/glue_schema_registry_deserializer.h
+++ b/native-schema-registry/c/include/glue_schema_registry_deserializer.h
@@ -12,7 +12,7 @@ typedef struct glue_schema_registry_deserializer {
     void *instance_context;
 } glue_schema_registry_deserializer;
 
-glue_schema_registry_deserializer *new_glue_schema_registry_deserializer(const char *config_file_path, glue_schema_registry_error **p_err);
+glue_schema_registry_deserializer *new_glue_schema_registry_deserializer(const char *config_file_path, const char *user_agent, glue_schema_registry_error **p_err);
 
 void delete_glue_schema_registry_deserializer(glue_schema_registry_deserializer *deserializer);
 

--- a/native-schema-registry/c/include/glue_schema_registry_serializer.h
+++ b/native-schema-registry/c/include/glue_schema_registry_serializer.h
@@ -11,7 +11,7 @@ typedef struct glue_schema_registry_serializer {
     void *instance_context;
 } glue_schema_registry_serializer;
 
-glue_schema_registry_serializer *new_glue_schema_registry_serializer(const char *config_file_path, glue_schema_registry_error **p_err);
+glue_schema_registry_serializer *new_glue_schema_registry_serializer(const char *config_file_path, const char *user_agent, glue_schema_registry_error **p_err);
 
 void delete_glue_schema_registry_serializer(glue_schema_registry_serializer *serializer);
 

--- a/native-schema-registry/c/src/glue_schema_registry_deserializer.c
+++ b/native-schema-registry/c/src/glue_schema_registry_deserializer.c
@@ -7,7 +7,8 @@ typedef struct {
     graal_isolate_t *isolate;
 } deserializer_context;
 
-glue_schema_registry_deserializer * new_glue_schema_registry_deserializer(const char *config_file_path, glue_schema_registry_error **p_err) {
+glue_schema_registry_deserializer *new_glue_schema_registry_deserializer(const char *config_file_path, const char *user_agent, glue_schema_registry_error **p_err)
+{
     glue_schema_registry_deserializer *deserializer = NULL;
     deserializer =
             (glue_schema_registry_deserializer *) aws_common_malloc(sizeof(glue_schema_registry_deserializer));
@@ -28,8 +29,8 @@ glue_schema_registry_deserializer * new_glue_schema_registry_deserializer(const 
     deserializer->instance_context = ctx;
 
     //Initialize with configuration file (can be NULL for default configuration)
-    int config_result = initialize_deserializer_with_config(thread, (char*)config_file_path, p_err);
-    
+    int config_result = initialize_deserializer_with_config(thread, (char *)config_file_path, (char *)user_agent, p_err);
+
     if (config_result != 0) {
         delete_glue_schema_registry_deserializer(deserializer);
         // Only throw an error if one wasn't already set by initialize_deserializer_with_config

--- a/native-schema-registry/c/src/glue_schema_registry_serializer.c
+++ b/native-schema-registry/c/src/glue_schema_registry_serializer.c
@@ -7,7 +7,7 @@ typedef struct {
     graal_isolate_t *isolate;
 } serializer_context;
 
-glue_schema_registry_serializer *new_glue_schema_registry_serializer(const char *config_file_path, glue_schema_registry_error **p_err) {
+glue_schema_registry_serializer *new_glue_schema_registry_serializer(const char *config_file_path, const char *user_agent, glue_schema_registry_error **p_err) {
     glue_schema_registry_serializer *serializer = NULL;
     serializer = (glue_schema_registry_serializer *) aws_common_malloc(sizeof(glue_schema_registry_serializer));
     serializer->instance_context = NULL;
@@ -29,7 +29,7 @@ glue_schema_registry_serializer *new_glue_schema_registry_serializer(const char 
     serializer->instance_context = ctx;
 
     //Initialize with configuration file using main thread
-    int config_result = initialize_serializer_with_config(thread, (char*)config_file_path, p_err);
+    int config_result = initialize_serializer_with_config(thread, (char*)config_file_path, (char*)user_agent, p_err);
     
     if (config_result != 0) {
         delete_glue_schema_registry_serializer(serializer);

--- a/native-schema-registry/c/src/swig/glue_schema_registry_deserializer.i
+++ b/native-schema-registry/c/src/swig/glue_schema_registry_deserializer.i
@@ -14,8 +14,8 @@ typedef struct glue_schema_registry_deserializer {
     %extend {
         //Exception argument will be intercepted and thrown as exception in target language.
         //It is 2nd argument as there is no '$self' argument passed for constructor methods.
-        %exception new_glue_schema_registry_deserializer %glue_schema_registry_exception_interceptor(arg2)
-        glue_schema_registry_deserializer(const char *config_file_path, glue_schema_registry_error **p_err);
+        %exception new_glue_schema_registry_deserializer %glue_schema_registry_exception_interceptor(arg3)
+        glue_schema_registry_deserializer(const char *config_file_path, const char *user_agent, glue_schema_registry_error **p_err);
 
         ~glue_schema_registry_deserializer();
 

--- a/native-schema-registry/c/src/swig/glue_schema_registry_serializer.i
+++ b/native-schema-registry/c/src/swig/glue_schema_registry_serializer.i
@@ -14,8 +14,8 @@ typedef struct glue_schema_registry_serializer {
     %extend {
         //Exception argument will be intercepted and thrown as exception in target language.
         //It is 2nd argument as there is no '$self' argument passed for constructor methods.
-        %exception new_glue_schema_registry_serializer %glue_schema_registry_exception_interceptor(arg2)
-        glue_schema_registry_serializer(const char *config_file_path, glue_schema_registry_error **p_err);
+        %exception new_glue_schema_registry_serializer %glue_schema_registry_exception_interceptor(arg3)
+        glue_schema_registry_serializer(const char *config_file_path, const char *user_agent, glue_schema_registry_error **p_err);
 
         ~glue_schema_registry_serializer();
 

--- a/native-schema-registry/c/test/glue_schema_registry_deserializer_test.c
+++ b/native-schema-registry/c/test/glue_schema_registry_deserializer_test.c
@@ -6,7 +6,7 @@
 
 static void test_new_glue_schema_registry_deserializer_created_successfully(void **state) {
     set_mock_state(GRAAL_VM_INIT_SUCCESS);
-    glue_schema_registry_deserializer *gsr_deserializer = new_glue_schema_registry_deserializer(NULL, NULL);
+    glue_schema_registry_deserializer *gsr_deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", NULL);
 
     assert_non_null(gsr_deserializer);
     assert_non_null(gsr_deserializer->instance_context);
@@ -20,7 +20,7 @@ static void test_new_glue_schema_registry_deserializer_init_fails_throws_excepti
     set_mock_state(GRAAL_VM_INIT_FAIL);
 
     glue_schema_registry_error **p_err = new_glue_schema_registry_error_holder();
-    glue_schema_registry_deserializer *gsr_deserializer = new_glue_schema_registry_deserializer(NULL, p_err);
+    glue_schema_registry_deserializer *gsr_deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", p_err);
 
     assert_null(gsr_deserializer);
     assert_error_and_clear(p_err, "Failed to initialize GraalVM isolate.", ERR_CODE_GRAALVM_INIT_EXCEPTION);
@@ -34,7 +34,7 @@ static void test_new_glue_schema_registry_deserializer_config_init_fails_throws_
     set_mock_state(CONFIG_INIT_DESERIALIZER_FAIL);
 
     glue_schema_registry_error **p_err = new_glue_schema_registry_error_holder();
-    glue_schema_registry_deserializer *gsr_deserializer = new_glue_schema_registry_deserializer(NULL, p_err);
+    glue_schema_registry_deserializer *gsr_deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", p_err);
 
     assert_null(gsr_deserializer);
     assert_error_and_clear(p_err, "Failed to initialize deserializer with configuration file.", ERR_CODE_RUNTIME_ERROR);
@@ -48,7 +48,7 @@ static void test_new_glue_schema_registry_deserializer_deletes_instance(void **s
     set_mock_state(GRAAL_VM_INIT_SUCCESS);
 
     glue_schema_registry_error **p_err = new_glue_schema_registry_error_holder();
-    glue_schema_registry_deserializer *gsr_deserializer = new_glue_schema_registry_deserializer(NULL, p_err);
+    glue_schema_registry_deserializer *gsr_deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", p_err);
 
     assert_non_null(gsr_deserializer);
     delete_glue_schema_registry_deserializer(gsr_deserializer);
@@ -65,7 +65,7 @@ static void test_new_glue_schema_registry_deserializer_delete_ignores_NULL_deser
 static void test_new_glue_schema_registry_deserializer_delete_ignores_tear_down_failure(void **state) {
     set_mock_state(TEAR_DOWN_FAIL);
 
-    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, NULL);
+    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", NULL);
     delete_glue_schema_registry_deserializer(deserializer);
 
     clear_mock_state();
@@ -76,7 +76,7 @@ static void test_new_glue_schema_registry_deserializer_decodes_successfully(void
 
     read_only_byte_array *arr = get_read_only_byte_array_fixture();
 
-    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, NULL);
+    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", NULL);
 
     mutable_byte_array *mut_byte_array = glue_schema_registry_deserializer_decode(
             deserializer,
@@ -103,7 +103,7 @@ static void test_new_glue_schema_registry_deserializer_decode_throws_exception(v
     read_only_byte_array *arr = get_read_only_byte_array_fixture();
     glue_schema_registry_error **p_err = new_glue_schema_registry_error_holder();
 
-    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, NULL);
+    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", NULL);
 
     mutable_byte_array *mut_byte_array = glue_schema_registry_deserializer_decode(
             deserializer,
@@ -139,7 +139,7 @@ static void test_new_glue_schema_registry_deserializer_decode_arr_null_throws_ex
     set_mock_state(GRAAL_VM_INIT_SUCCESS);
 
     glue_schema_registry_error **p_err = new_glue_schema_registry_error_holder();
-    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, NULL);
+    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", NULL);
 
     mutable_byte_array *mutableByteArray = glue_schema_registry_deserializer_decode(
             deserializer,
@@ -160,7 +160,7 @@ static void test_new_glue_schema_registry_deserializer_decodes_schema_successful
 
     read_only_byte_array *arr = get_read_only_byte_array_fixture();
 
-    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, NULL);
+    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", NULL);
 
     glue_schema_registry_schema *schema = glue_schema_registry_deserializer_decode_schema(
             deserializer,
@@ -187,7 +187,7 @@ static void test_new_glue_schema_registry_deserializer_decode_schema_throws_exce
     read_only_byte_array *arr = get_read_only_byte_array_fixture();
     glue_schema_registry_error **p_err = new_glue_schema_registry_error_holder();
 
-    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, NULL);
+    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", NULL);
 
     glue_schema_registry_schema *schema = glue_schema_registry_deserializer_decode_schema(
             deserializer,
@@ -222,7 +222,7 @@ static void test_new_glue_schema_registry_deserializer_decode_schema_deserialize
 static void test_new_glue_schema_registry_deserializer_decode_schema_arr_null_throws_exception(void **state) {
     set_mock_state(GRAAL_VM_INIT_SUCCESS);
     glue_schema_registry_error **p_err = new_glue_schema_registry_error_holder();
-    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, NULL);
+    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", NULL);
 
     glue_schema_registry_schema *schema = glue_schema_registry_deserializer_decode_schema(
             deserializer,
@@ -242,7 +242,7 @@ static void test_new_glue_schema_registry_deserializer_can_decode_successfully(v
     set_mock_state(GRAAL_VM_INIT_SUCCESS);
     read_only_byte_array *arr = get_read_only_byte_array_fixture();
 
-    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, NULL);
+    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", NULL);
 
     bool can_decode = glue_schema_registry_deserializer_can_decode(
             deserializer,
@@ -263,7 +263,7 @@ static void test_new_glue_schema_registry_deserializer_can_decode_throws_excepti
     read_only_byte_array *arr = get_read_only_byte_array_fixture();
     glue_schema_registry_error **p_err = new_glue_schema_registry_error_holder();
 
-    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, NULL);
+    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", NULL);
 
     bool can_decode = glue_schema_registry_deserializer_can_decode(
             deserializer,
@@ -298,7 +298,7 @@ static void test_new_glue_schema_registry_deserializer_can_decode_deserializer_n
 static void test_new_glue_schema_registry_deserializer_can_decode_arr_null_throws_exception(void **state) {
     set_mock_state(GRAAL_VM_INIT_SUCCESS);
     glue_schema_registry_error **p_err = new_glue_schema_registry_error_holder();
-    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, NULL);
+    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", NULL);
 
     bool can_decode = glue_schema_registry_deserializer_can_decode(
             deserializer,
@@ -316,7 +316,7 @@ static void test_new_glue_schema_registry_deserializer_can_decode_arr_null_throw
 
 static void test_deserializer_decode_attach_thread_failure(void **state) {
     set_mock_state(GRAAL_VM_INIT_SUCCESS);
-    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, NULL);
+    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", NULL);
 
     set_mock_state(ATTACH_THREAD_FAIL);
 
@@ -335,7 +335,7 @@ static void test_deserializer_decode_attach_thread_failure(void **state) {
 
 static void test_deserializer_decode_schema_attach_thread_failure(void **state) {
     set_mock_state(GRAAL_VM_INIT_SUCCESS);
-    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, NULL);
+    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", NULL);
 
     set_mock_state(ATTACH_THREAD_FAIL);
 
@@ -354,7 +354,7 @@ static void test_deserializer_decode_schema_attach_thread_failure(void **state) 
 
 static void test_deserializer_can_decode_attach_thread_failure(void **state) {
     set_mock_state(GRAAL_VM_INIT_SUCCESS);
-    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, NULL);
+    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", NULL);
 
     set_mock_state(ATTACH_THREAD_FAIL);
 
@@ -373,7 +373,7 @@ static void test_deserializer_can_decode_attach_thread_failure(void **state) {
 
 static void test_deserializer_decode_detach_thread_failure(void **state) {
     set_mock_state(GRAAL_VM_INIT_SUCCESS);
-    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, NULL);
+    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", NULL);
 
     set_mock_state(DETACH_THREAD_FAIL);
 
@@ -390,7 +390,7 @@ static void test_deserializer_decode_detach_thread_failure(void **state) {
 
 static void test_deserializer_decode_schema_detach_thread_failure(void **state) {
     set_mock_state(GRAAL_VM_INIT_SUCCESS);
-    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, NULL);
+    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", NULL);
 
     set_mock_state(DETACH_THREAD_FAIL);
 
@@ -407,7 +407,7 @@ static void test_deserializer_decode_schema_detach_thread_failure(void **state) 
 
 static void test_deserializer_can_decode_detach_thread_failure(void **state) {
     set_mock_state(GRAAL_VM_INIT_SUCCESS);
-    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, NULL);
+    glue_schema_registry_deserializer *deserializer = new_glue_schema_registry_deserializer(NULL, "test-user-agent", NULL);
 
     set_mock_state(DETACH_THREAD_FAIL);
 

--- a/native-schema-registry/c/test/glue_schema_registry_serializer_test.c
+++ b/native-schema-registry/c/test/glue_schema_registry_serializer_test.c
@@ -7,7 +7,7 @@
 
 static void test_new_glue_schema_registry_serializer_created_successfully(void **state) {
     set_mock_state(GRAAL_VM_INIT_SUCCESS);
-    glue_schema_registry_serializer *gsr_serializer = new_glue_schema_registry_serializer(NULL, NULL);
+    glue_schema_registry_serializer *gsr_serializer = new_glue_schema_registry_serializer(NULL, "test-user-agent", NULL);
 
     assert_non_null(gsr_serializer);
     assert_non_null(gsr_serializer->instance_context);
@@ -21,7 +21,7 @@ static void test_new_glue_schema_registry_serializer_init_fails_throws_exception
     set_mock_state(GRAAL_VM_INIT_FAIL);
 
     glue_schema_registry_error **p_err = new_glue_schema_registry_error_holder();
-    glue_schema_registry_serializer *gsr_serializer = new_glue_schema_registry_serializer(NULL, p_err);
+    glue_schema_registry_serializer *gsr_serializer = new_glue_schema_registry_serializer(NULL, "test-user-agent", p_err);
 
     assert_null(gsr_serializer);
     assert_error_and_clear(p_err, "Failed to initialize GraalVM isolate.", ERR_CODE_GRAALVM_INIT_EXCEPTION);
@@ -35,7 +35,7 @@ static void test_new_glue_schema_registry_serializer_config_init_fails_throws_ex
     set_mock_state(CONFIG_INIT_SERIALIZER_FAIL);
 
     glue_schema_registry_error **p_err = new_glue_schema_registry_error_holder();
-    glue_schema_registry_serializer *gsr_serializer = new_glue_schema_registry_serializer(NULL, p_err);
+    glue_schema_registry_serializer *gsr_serializer = new_glue_schema_registry_serializer(NULL, "test-user-agent", p_err);
 
     assert_null(gsr_serializer);
     assert_error_and_clear(p_err, "Failed to initialize serializer with configuration file.", ERR_CODE_RUNTIME_ERROR);
@@ -49,7 +49,7 @@ static void test_new_glue_schema_registry_serializer_deletes_instance(void **sta
     set_mock_state(GRAAL_VM_INIT_SUCCESS);
 
     glue_schema_registry_error **p_err = new_glue_schema_registry_error_holder();
-    glue_schema_registry_serializer *gsr_serializer = new_glue_schema_registry_serializer(NULL, p_err);
+    glue_schema_registry_serializer *gsr_serializer = new_glue_schema_registry_serializer(NULL, "test-user-agent", p_err);
 
     assert_non_null(gsr_serializer);
     delete_glue_schema_registry_serializer(gsr_serializer);
@@ -65,7 +65,7 @@ static void test_new_glue_schema_registry_serializer_delete_ignores_NULL_seriali
 
 static void test_new_glue_schema_registry_serializer_delete_ignores_tear_down_failure(void **state) {
     set_mock_state(TEAR_DOWN_FAIL);
-    glue_schema_registry_serializer *serializer = new_glue_schema_registry_serializer(NULL, NULL);
+    glue_schema_registry_serializer *serializer = new_glue_schema_registry_serializer(NULL, "test-user-agent", NULL);
     delete_glue_schema_registry_serializer(serializer);
 
     clear_mock_state();
@@ -78,7 +78,7 @@ static void test_new_glue_schema_registry_serializer_encodes_successfully(void *
     glue_schema_registry_schema *schema = get_gsr_schema_fixture();
     read_only_byte_array *arr = get_read_only_byte_array_fixture();
 
-    glue_schema_registry_serializer *serializer = new_glue_schema_registry_serializer(NULL, NULL);
+    glue_schema_registry_serializer *serializer = new_glue_schema_registry_serializer(NULL, "test-user-agent", NULL);
 
     mutable_byte_array *mut_byte_array = glue_schema_registry_serializer_encode(
             serializer,
@@ -109,7 +109,7 @@ static void test_new_glue_schema_registry_serializer_encode_throws_exception(voi
     read_only_byte_array *arr = get_read_only_byte_array_fixture();
     glue_schema_registry_error **p_err = new_glue_schema_registry_error_holder();
 
-    glue_schema_registry_serializer *serializer = new_glue_schema_registry_serializer(NULL, NULL);
+    glue_schema_registry_serializer *serializer = new_glue_schema_registry_serializer(NULL, "test-user-agent", NULL);
 
     mutable_byte_array *mut_byte_array = glue_schema_registry_serializer_encode(
             serializer,
@@ -154,7 +154,7 @@ static void test_new_glue_schema_registry_serializer_encode_schema_null_throws_e
     const char *transport_name = get_transport_name_fixture();
     read_only_byte_array *arr = get_read_only_byte_array_fixture();
     glue_schema_registry_error **p_err = new_glue_schema_registry_error_holder();
-    glue_schema_registry_serializer *serializer = new_glue_schema_registry_serializer(NULL, NULL);
+    glue_schema_registry_serializer *serializer = new_glue_schema_registry_serializer(NULL, "test-user-agent", NULL);
 
     mutable_byte_array *mutableByteArray = glue_schema_registry_serializer_encode(
             serializer,
@@ -178,7 +178,7 @@ static void test_new_glue_schema_registry_serializer_encode_arr_null_throws_exce
     const char *transport_name = get_transport_name_fixture();
     glue_schema_registry_schema *schema = get_gsr_schema_fixture();
     glue_schema_registry_error **p_err = new_glue_schema_registry_error_holder();
-    glue_schema_registry_serializer *serializer = new_glue_schema_registry_serializer(NULL, NULL);
+    glue_schema_registry_serializer *serializer = new_glue_schema_registry_serializer(NULL, "test-user-agent", NULL);
 
     mutable_byte_array *mutableByteArray = glue_schema_registry_serializer_encode(
             serializer,
@@ -199,7 +199,7 @@ static void test_new_glue_schema_registry_serializer_encode_arr_null_throws_exce
 
 static void test_serializer_encode_attach_thread_failure(void **state) {
     set_mock_state(GRAAL_VM_INIT_SUCCESS);
-    glue_schema_registry_serializer *gsr_serializer = new_glue_schema_registry_serializer(NULL, NULL);
+    glue_schema_registry_serializer *gsr_serializer = new_glue_schema_registry_serializer(NULL, "test-user-agent", NULL);
 
     set_mock_state(ATTACH_THREAD_FAIL);
 
@@ -220,7 +220,7 @@ static void test_serializer_encode_attach_thread_failure(void **state) {
 
 static void test_serializer_encode_detach_thread_failure(void **state) {
     set_mock_state(GRAAL_VM_INIT_SUCCESS);
-    glue_schema_registry_serializer *gsr_serializer = new_glue_schema_registry_serializer(NULL, NULL);
+    glue_schema_registry_serializer *gsr_serializer = new_glue_schema_registry_serializer(NULL, "test-user-agent", NULL);
 
     set_mock_state(DETACH_THREAD_FAIL);
 

--- a/native-schema-registry/c/test/libnativeschemaregistry_mock.c
+++ b/native-schema-registry/c/test/libnativeschemaregistry_mock.c
@@ -120,7 +120,8 @@ void initialize_deserializer(graal_isolatethread_t* thread) {
     //do nothing
 }
 
-int initialize_serializer_with_config(graal_isolatethread_t* thread, char* config_file_path, glue_schema_registry_error** p_err) {
+int initialize_serializer_with_config(graal_isolatethread_t *thread, char *config_file_path, char *user_agent, glue_schema_registry_error **p_err)
+{
     validate_mock_state();
 
     assert_non_null(thread);
@@ -134,7 +135,8 @@ int initialize_serializer_with_config(graal_isolatethread_t* thread, char* confi
     return 0;
 }
 
-int initialize_deserializer_with_config(graal_isolatethread_t* thread, char* config_file_path, glue_schema_registry_error** p_err) {
+int initialize_deserializer_with_config(graal_isolatethread_t *thread, char *config_file_path, char *user_agent, glue_schema_registry_error **p_err)
+{
     validate_mock_state();
 
     assert_non_null(thread);

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/GlueSchemaRegistryDeserializer.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/GlueSchemaRegistryDeserializer.cs
@@ -18,7 +18,7 @@ namespace AWSGsrSerDe
         {   
             try
             {
-                _deserializer = new glue_schema_registry_deserializer(configFilePath, null);
+                _deserializer = new glue_schema_registry_deserializer(configFilePath, GlueSchemaRegistryConstants.CSharpUserAgentString, null);
             }
             catch (Exception e)
             {

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/GlueSchemaRegistrySerializer.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/GlueSchemaRegistrySerializer.cs
@@ -32,7 +32,7 @@ namespace AWSGsrSerDe
         {
             try
             {
-                _serializer = new glue_schema_registry_serializer(configFilePath, null);
+                _serializer = new glue_schema_registry_serializer(configFilePath, GlueSchemaRegistryConstants.CSharpUserAgentString, null);
             }
             catch (Exception e)
             {

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/common/GlueSchemaRegistryConstants.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/common/GlueSchemaRegistryConstants.cs
@@ -25,6 +25,7 @@ namespace AWSGsrSerDe.common
         public const string ProtobufMessageDescriptor = "protobufMessageDescriptor";
         public const string JsonObjectType = "jsonObjectType";
         public const string CacheItemExpirationTime = "cacheItemExpirationTime";
+        public const string CSharpUserAgentString = "csharp";
 
         // TODO: need to expose it from Java to avoid code duplication
         public enum DataFormat

--- a/native-schema-registry/golang/pkg/gsrserde-go/common/constants.go
+++ b/native-schema-registry/golang/pkg/gsrserde-go/common/constants.go
@@ -41,6 +41,8 @@ const (
 	DataFormatProtobuf
 )
 
+const UserAgentString = "go"
+
 // String returns the string representation of the DataFormat.
 func (d DataFormat) String() string {
 	switch d {

--- a/native-schema-registry/golang/pkg/gsrserde-go/deserializer.go
+++ b/native-schema-registry/golang/pkg/gsrserde-go/deserializer.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"runtime"
 	"unsafe"
+
+	"github.com/awslabs/aws-glue-schema-registry/native-schema-registry/golang/pkg/gsrserde-go/common"
 )
 
 /*
@@ -23,12 +25,15 @@ func NewDeserializer(configPath string) (*Deserializer, error) {
 
 	cString := C.CString(configPath)
 	defer C.free(unsafe.Pointer(cString))
+	
+	cUserAgent := C.CString(common.UserAgentString)
+	defer C.free(unsafe.Pointer(cUserAgent))
 
 	errHolder := C.new_glue_schema_registry_error_holder()
 	defer C.delete_glue_schema_registry_error_holder(errHolder)
 
 	// Create native deserializer
-	deserializer := C.new_glue_schema_registry_deserializer(cString, errHolder)
+	deserializer := C.new_glue_schema_registry_deserializer(cString, cUserAgent, errHolder)
 
 	if *errHolder != nil {
 		return nil, extractError("create deserializer", *errHolder)

--- a/native-schema-registry/golang/pkg/gsrserde-go/serializer.go
+++ b/native-schema-registry/golang/pkg/gsrserde-go/serializer.go
@@ -3,6 +3,8 @@ package gsrserde
 import (
 	"runtime"
 	"unsafe"
+
+	"github.com/awslabs/aws-glue-schema-registry/native-schema-registry/golang/pkg/gsrserde-go/common"
 )
 
 /*
@@ -27,10 +29,13 @@ func NewSerializer(configPath string) (*Serializer, error) {
 	cString := C.CString(configPath)
 	defer C.free(unsafe.Pointer(cString))
 	
+	cUserAgent := C.CString(common.UserAgentString)
+	defer C.free(unsafe.Pointer(cUserAgent))
+
 	errHolder := C.new_glue_schema_registry_error_holder()
 	defer C.delete_glue_schema_registry_error_holder(errHolder)
 	
-	serializer := C.new_glue_schema_registry_serializer(cString, errHolder)
+	serializer := C.new_glue_schema_registry_serializer(cString, cUserAgent, errHolder)
 	
 	// Check for errors
 	if *errHolder != nil {

--- a/native-schema-registry/src/main/java/com/amazonaws/services/schemaregistry/GlueSchemaRegistryDeserializationHandler.java
+++ b/native-schema-registry/src/main/java/com/amazonaws/services/schemaregistry/GlueSchemaRegistryDeserializationHandler.java
@@ -28,6 +28,7 @@ import static com.amazonaws.services.schemaregistry.DataTypes.C_MutableByteArray
 import static com.amazonaws.services.schemaregistry.DataTypes.C_ReadOnlyByteArray;
 import static com.amazonaws.services.schemaregistry.DataTypes.HandlerDirectives;
 import static com.amazonaws.services.schemaregistry.DataTypes.newGlueSchemaRegistrySchema;
+import static com.amazonaws.services.schemaregistry.config.NativeGlueSchemaRegistryConfiguration.USER_AGENT_APP_KEY;
 
 /**
  * Entry point class for the serialization methods of GSR shared library.
@@ -55,6 +56,7 @@ public class GlueSchemaRegistryDeserializationHandler {
     public static int initializeDeserializerWithConfig(
         IsolateThread isolateThread,
         CCharPointer configFilePath,
+        CCharPointer userAgentApp,
         C_GlueSchemaRegistryErrorPointerHolder errorPointer) {
         try {
             if (configFilePath.isNull()) {
@@ -63,9 +65,12 @@ public class GlueSchemaRegistryDeserializationHandler {
                 return 0;
             }
 
-            String filePath = CTypeConversion.toJavaString(configFilePath);
-            Map<String, String> configs = ConfigurationFileReader.loadConfigFromFile(filePath);
-            NativeGlueSchemaRegistryConfiguration configuration = new NativeGlueSchemaRegistryConfiguration(configs);
+            final String filePath = CTypeConversion.toJavaString(configFilePath);
+            final String userAgent = CTypeConversion.toJavaString(userAgentApp);
+            final Map<String, String> configs = ConfigurationFileReader.loadConfigFromFile(filePath);
+            configs.put(USER_AGENT_APP_KEY, userAgent);
+            final NativeGlueSchemaRegistryConfiguration configuration =
+                new NativeGlueSchemaRegistryConfiguration(configs);
             DeserializerInstance.create(configuration);
 
             return 0; // Success

--- a/native-schema-registry/src/main/java/com/amazonaws/services/schemaregistry/GlueSchemaRegistrySerializationHandler.java
+++ b/native-schema-registry/src/main/java/com/amazonaws/services/schemaregistry/GlueSchemaRegistrySerializationHandler.java
@@ -28,7 +28,7 @@ import static com.amazonaws.services.schemaregistry.DataTypes.C_GlueSchemaRegist
 import static com.amazonaws.services.schemaregistry.DataTypes.C_MutableByteArray;
 import static com.amazonaws.services.schemaregistry.DataTypes.C_ReadOnlyByteArray;
 import static com.amazonaws.services.schemaregistry.DataTypes.HandlerDirectives;
-
+import static com.amazonaws.services.schemaregistry.config.NativeGlueSchemaRegistryConfiguration.USER_AGENT_APP_KEY;
 /**
  * Entry point class for the serialization methods of GSR shared library.
  */
@@ -57,16 +57,20 @@ public class GlueSchemaRegistrySerializationHandler {
     public static int initializeSerializerWithConfig(
         IsolateThread isolateThread,
         CCharPointer configFilePath,
-        C_GlueSchemaRegistryErrorPointerHolder errorPointer) {
+        CCharPointer userAgentApp,
+            C_GlueSchemaRegistryErrorPointerHolder errorPointer) {
         try {
             if (configFilePath.isNull()) {
                 // Use default configuration when no config file provided
                 initializeSerializer(isolateThread);
                 return 0;
             }
-            String filePath = CTypeConversion.toJavaString(configFilePath);
+            final String filePath = CTypeConversion.toJavaString(configFilePath);
+            final String userAgent = CTypeConversion.toJavaString(userAgentApp);
             Map<String, String> configs = ConfigurationFileReader.loadConfigFromFile(filePath);
-            NativeGlueSchemaRegistryConfiguration configuration = new NativeGlueSchemaRegistryConfiguration(configs);
+            configs.put(USER_AGENT_APP_KEY, userAgent);
+            NativeGlueSchemaRegistryConfiguration configuration =
+                new NativeGlueSchemaRegistryConfiguration(configs);
             SerializerInstance.create(configuration);
             return 0;
         } catch (Exception e) {

--- a/native-schema-registry/src/main/java/com/amazonaws/services/schemaregistry/config/ConfigurationFileReader.java
+++ b/native-schema-registry/src/main/java/com/amazonaws/services/schemaregistry/config/ConfigurationFileReader.java
@@ -31,6 +31,9 @@ public class ConfigurationFileReader {
             }
         }
 
+        // removing userAgentApp as this should be set according to serde object creation and not user configuration
+        configMap.remove(NativeGlueSchemaRegistryConfiguration.USER_AGENT_APP_KEY);
+
         return configMap;
     }
 }

--- a/native-schema-registry/src/main/java/com/amazonaws/services/schemaregistry/config/NativeGlueSchemaRegistryConfiguration.java
+++ b/native-schema-registry/src/main/java/com/amazonaws/services/schemaregistry/config/NativeGlueSchemaRegistryConfiguration.java
@@ -45,7 +45,7 @@ public class NativeGlueSchemaRegistryConfiguration extends GlueSchemaRegistryCon
     private void validateAndSetRoleConfiguration(Map<String, ?> configs) {
         if (configs.containsKey("roleToAssume")) {
             this.roleToAssume = (String) configs.get("roleToAssume");
-            this.roleSessionName = "native-glue-schema-registry";
+            this.roleSessionName = "native";
         }
         if (configs.containsKey("roleSessionName")) {
             this.roleSessionName = (String) configs.get("roleSessionName"); // this will override the default session

--- a/native-schema-registry/src/main/java/com/amazonaws/services/schemaregistry/config/NativeGlueSchemaRegistryConfiguration.java
+++ b/native-schema-registry/src/main/java/com/amazonaws/services/schemaregistry/config/NativeGlueSchemaRegistryConfiguration.java
@@ -14,25 +14,32 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import java.util.Map;
 import java.util.Properties;
-
 @Slf4j
 @Data
 public class NativeGlueSchemaRegistryConfiguration extends GlueSchemaRegistryConfiguration {
     private String roleToAssume;
     private String roleSessionName; // should only be set if roleToAssumeIsSet
 
+    public static final String ROLE_TO_ASSUME_KEY = "roleToAssume";
+    public static final String ROLE_SESSION_NAME_KEY = "roleSessionName";
+    public static final String USER_AGENT_APP_KEY = "userAgentApp";
+
     public NativeGlueSchemaRegistryConfiguration(String region) {
         super(region);
+        this.setUserAgentApp("native-glue-schema-registry");
     }
 
     public NativeGlueSchemaRegistryConfiguration(Map<String, ?> configs) {
         super(configs);
         validateAndSetRoleConfiguration(configs);
+        validateAndSetUserAgentApp(configs);
     }
 
     public NativeGlueSchemaRegistryConfiguration(Properties properties) {
         super(properties);
-        validateAndSetRoleConfiguration(getMapFromPropertiesFile(properties));
+        final Map<String, ?> configs = getMapFromPropertiesFile(properties);
+        validateAndSetRoleConfiguration(configs);
+        validateAndSetUserAgentApp(configs);
     }
 
     private void validateAndSetRoleConfiguration(Map<String, ?> configs) {
@@ -44,6 +51,15 @@ public class NativeGlueSchemaRegistryConfiguration extends GlueSchemaRegistryCon
             this.roleSessionName = (String) configs.get("roleSessionName"); // this will override the default session
                                                                             // name if there is a roleSessionName
                                                                             // defined by user
+        }
+    }
+
+    private void validateAndSetUserAgentApp(Map<String, ?> configs) {
+        if (configs.containsKey("userAgentApp")) {
+            final String userAgentApp = (String) configs.get("userAgentApp");
+            this.setUserAgentApp(userAgentApp);
+        } else {
+            this.setUserAgentApp("native-glue-schema-registry");
         }
     }
 

--- a/native-schema-registry/src/main/java/com/amazonaws/services/schemaregistry/config/NativeGlueSchemaRegistryConfiguration.java
+++ b/native-schema-registry/src/main/java/com/amazonaws/services/schemaregistry/config/NativeGlueSchemaRegistryConfiguration.java
@@ -26,7 +26,7 @@ public class NativeGlueSchemaRegistryConfiguration extends GlueSchemaRegistryCon
 
     public NativeGlueSchemaRegistryConfiguration(String region) {
         super(region);
-        this.setUserAgentApp("native-glue-schema-registry");
+        this.setUserAgentApp("native");
     }
 
     public NativeGlueSchemaRegistryConfiguration(Map<String, ?> configs) {
@@ -59,7 +59,7 @@ public class NativeGlueSchemaRegistryConfiguration extends GlueSchemaRegistryCon
             final String userAgentApp = (String) configs.get("userAgentApp");
             this.setUserAgentApp(userAgentApp);
         } else {
-            this.setUserAgentApp("native-glue-schema-registry");
+            this.setUserAgentApp("native");
         }
     }
 

--- a/native-schema-registry/test/java/com/amazonaws/services/schemaregistry/config/NativeGlueSchemaRegistryConfigurationTest.java
+++ b/native-schema-registry/test/java/com/amazonaws/services/schemaregistry/config/NativeGlueSchemaRegistryConfigurationTest.java
@@ -16,11 +16,14 @@ class NativeGlueSchemaRegistryConfigurationTest {
     private static final String REGION_KEY = "region";
     private static final String ROLE_TO_ASSUME_KEY = "roleToAssume";
     private static final String ROLE_SESSION_NAME_KEY = "roleSessionName";
+    private static final String USER_AGENT_APP_KEY = "userAgentApp";
     
     private static final String REGION_VALUE = "us-east-1";
     private static final String ROLE_ARN_VALUE = "arn:aws:iam::123456789012:role/TestRole";
     private static final String DEFAULT_SESSION_NAME = "native-glue-schema-registry";
     private static final String CUSTOM_SESSION_NAME = "custom-session-name";
+    private static final String DEFAULT_USER_AGENT_APP = "native-glue-schema-registry";
+    private static final String CUSTOM_USER_AGENT_APP = "custom-user-agent-app";
 
     @Test
     void testDefaultSessionNameSetWhenRoleConfiguredButSessionNameNot() {
@@ -82,5 +85,47 @@ class NativeGlueSchemaRegistryConfigurationTest {
         
         assertEquals(ROLE_ARN_VALUE, config.getRoleToAssume());
         assertEquals(DEFAULT_SESSION_NAME, config.getRoleSessionName());
+    }
+
+    @Test
+    void testUserAgentAppSetWhenConfigured() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(REGION_KEY, REGION_VALUE);
+        configs.put(USER_AGENT_APP_KEY, CUSTOM_USER_AGENT_APP);
+        
+        NativeGlueSchemaRegistryConfiguration config = new NativeGlueSchemaRegistryConfiguration(configs);
+        
+        assertEquals(CUSTOM_USER_AGENT_APP, config.getUserAgentApp());
+    }
+
+    @Test
+    void testDefaultUserAgentAppSetWhenNotConfigured() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(REGION_KEY, REGION_VALUE);
+        
+        NativeGlueSchemaRegistryConfiguration config = new NativeGlueSchemaRegistryConfiguration(configs);
+        
+        assertEquals(DEFAULT_USER_AGENT_APP, config.getUserAgentApp());
+    }
+
+    @Test
+    void testUserAgentAppFromPropertiesConstructor() {
+        Properties properties = new Properties();
+        properties.setProperty(REGION_KEY, REGION_VALUE);
+        properties.setProperty(USER_AGENT_APP_KEY, CUSTOM_USER_AGENT_APP);
+        
+        NativeGlueSchemaRegistryConfiguration config = new NativeGlueSchemaRegistryConfiguration(properties);
+        
+        assertEquals(CUSTOM_USER_AGENT_APP, config.getUserAgentApp());
+    }
+
+    @Test
+    void testDefaultUserAgentAppFromPropertiesConstructor() {
+        Properties properties = new Properties();
+        properties.setProperty(REGION_KEY, REGION_VALUE);
+        
+        NativeGlueSchemaRegistryConfiguration config = new NativeGlueSchemaRegistryConfiguration(properties);
+        
+        assertEquals(DEFAULT_USER_AGENT_APP, config.getUserAgentApp());
     }
 }


### PR DESCRIPTION
This pull request introduces support for passing a `user_agent` parameter to the constructors of both the serializer and deserializer in the Glue Schema Registry C bindings.  The changes update the function signatures, implementation code, SWIG interface files, and all relevant tests to accommodate the new parameter.

### API and Implementation Changes

* Added a `user_agent` parameter to the constructors of `glue_schema_registry_deserializer` and `glue_schema_registry_serializer` in both header files (`glue_schema_registry_deserializer.h`, `glue_schema_registry_serializer.h`) and implementation files (`glue_schema_registry_deserializer.c`, `glue_schema_registry_serializer.c`). The initialization functions now pass this parameter to their respective configuration routines. [[1]](diffhunk://#diff-12128e28b8e6a2bc1e6118c7ae6f4afe17d20741f737b5242d747b8c7aff1b4aL15-R15) [[2]](diffhunk://#diff-d781ed371d2786095844ac368a57ef2f7fa7d88b94e13503105357fad219542eL14-R14) [[3]](diffhunk://#diff-148b42c42cfeecf2428e39270def75795f953c2354dff747fbc3bbb3669e062eL10-R11) [[4]](diffhunk://#diff-148b42c42cfeecf2428e39270def75795f953c2354dff747fbc3bbb3669e062eL31-R32) [[5]](diffhunk://#diff-1391a2e7a630bf5f0d75a5e2dfd36fa0f39616c66912e58bccd3636e39fceda4L10-R10) [[6]](diffhunk://#diff-1391a2e7a630bf5f0d75a5e2dfd36fa0f39616c66912e58bccd3636e39fceda4L32-R32)

* Updated the SWIG interface files (`glue_schema_registry_deserializer.i`, `glue_schema_registry_serializer.i`) to reflect the new constructor signatures and ensure proper exception handling with the new argument position. [[1]](diffhunk://#diff-aa3c41f22594932c52756fa9cabbd3e65c228f7110c6cd77c071091e0099e0a4L17-R18) [[2]](diffhunk://#diff-0031ba74118686f2837a3f04c05281096df75d99e0cebdf6dadbcaed50bdc633L17-R18)

### Testing and Validation

* Modified all unit tests in `glue_schema_registry_deserializer_test.c` to use the new constructor signature, passing a test user agent string. This ensures coverage for the new parameter and maintains test validity. [[1]](diffhunk://#diff-e56dbe122859694d461a26a8ca1012380bcc956202c752080cc544898493b336L9-R9) [[2]](diffhunk://#diff-e56dbe122859694d461a26a8ca1012380bcc956202c752080cc544898493b336L23-R23) [[3]](diffhunk://#diff-e56dbe122859694d461a26a8ca1012380bcc956202c752080cc544898493b336L37-R37) [[4]](diffhunk://#diff-e56dbe122859694d461a26a8ca1012380bcc956202c752080cc544898493b336L51-R51) [[5]](diffhunk://#diff-e56dbe122859694d461a26a8ca1012380bcc956202c752080cc544898493b336L68-R68) [[6]](diffhunk://#diff-e56dbe122859694d461a26a8ca1012380bcc956202c752080cc544898493b336L79-R79) [[7]](diffhunk://#diff-e56dbe122859694d461a26a8ca1012380bcc956202c752080cc544898493b336L106-R106) [[8]](diffhunk://#diff-e56dbe122859694d461a26a8ca1012380bcc956202c752080cc544898493b336L142-R142) [[9]](diffhunk://#diff-e56dbe122859694d461a26a8ca1012380bcc956202c752080cc544898493b336L163-R163) [[10]](diffhunk://#diff-e56dbe122859694d461a26a8ca1012380bcc956202c752080cc544898493b336L190-R190) [[11]](diffhunk://#diff-e56dbe122859694d461a26a8ca1012380bcc956202c752080cc544898493b336L225-R225) [[12]](diffhunk://#diff-e56dbe122859694d461a26a8ca1012380bcc956202c752080cc544898493b336L245-R245) [[13]](diffhunk://#diff-e56dbe122859694d461a26a8ca1012380bcc956202c752080cc544898493b336L266-R266) [[14]](diffhunk://#diff-e56dbe122859694d461a26a8ca1012380bcc956202c752080cc544898493b336L301-R301) [[15]](diffhunk://#diff-e56dbe122859694d461a26a8ca1012380bcc956202c752080cc544898493b336L319-R319) [[16]](diffhunk://#diff-e56dbe122859694d461a26a8ca1012380bcc956202c752080cc544898493b336L338-R338) [[17]](diffhunk://#diff-e56dbe122859694d461a26a8ca1012380bcc956202c752080cc544898493b336L357-R357)
