### PR TITLE
Add config validation tests to test caching, compression, roleToAssume and other configs

### DIFF
--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/integ-tests/configuration/ConfigValidationIntegTests.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/integ-tests/configuration/ConfigValidationIntegTests.cs
@@ -292,6 +292,18 @@ namespace AWSGsrSerDe.Tests.Configuration
             return false;
         }
 
+        /// <summary>
+        /// Gets the full path to a shared test configuration file.
+        /// </summary>
+        /// <param name="configFileName">The name of the config file (e.g., "minimal-auto-registration-default-registry.properties")</param>
+        /// <returns>The full path to the configuration file</returns>
+        private string GetSharedConfigPath(string configFileName)
+        {
+            var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
+            var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs", configFileName);
+            return Path.GetFullPath(configPath);
+        }
+
 
         [Test]
         public async Task Constructor_WithValidMinimalConfig_AutoRegistersSchemaInDefaultRegistry()
@@ -310,9 +322,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with auto-registration enabled and no registry specification
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/minimal-auto-registration-default-registry.properties");
-                configPath = Path.GetFullPath(configPath);
+                configPath = GetSharedConfigPath("minimal-auto-registration-default-registry.properties");
 
                 // 2. Create GSR serializer with auto-registration enabled
                 Console.WriteLine($"Creating GSR serializer with config...");
@@ -387,9 +397,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with auto-registration enabled for custom registry (native-test-registry)
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/minimal-auto-registration-custom-registry.properties");
-                configPath = Path.GetFullPath(configPath);
+                var configPath = GetSharedConfigPath("minimal-auto-registration-custom-registry.properties");
 
                 // 2. Create GSR serializer with auto-registration enabled for custom registry
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -459,9 +467,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with mismatched region and endpoint
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/region-endpoint-mismatch.properties");
-                configPath = Path.GetFullPath(configPath);
+                configPath = GetSharedConfigPath("region-endpoint-mismatch.properties");
 
                 // 2. Create GSR serializer with mismatched config
                 TestContext.WriteLine("Creating GSR serializer with mismatched region/endpoint config...");
@@ -501,9 +507,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with invalid region
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/invalid-region.properties");
-                configPath = Path.GetFullPath(configPath);
+                configPath = GetSharedConfigPath("invalid-region.properties");
 
                 // 2. Create GSR serializer with invalid region config
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -543,9 +547,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with invalid endpoint
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/invalid-endpoint.properties");
-                configPath = Path.GetFullPath(configPath);
+                configPath = GetSharedConfigPath("invalid-endpoint.properties");
 
                 // 2. Create GSR serializer with invalid endpoint config
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -584,9 +586,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with non-existent registry
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/inexistent-registry.properties");
-                configPath = Path.GetFullPath(configPath);
+                var configPath = GetSharedConfigPath("inexistent-registry.properties");
 
                 // 2. Create GSR serializer with non-existent registry config
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -625,9 +625,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with invalid role ARN
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/invalid-role-to-assume.properties");
-                configPath = Path.GetFullPath(configPath);
+                var configPath = GetSharedConfigPath("invalid-role-to-assume.properties");
 
                 // 2. Create GSR serializer with invalid role config
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -682,9 +680,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with different region registry
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/different-region-registry.properties");
-                configPath = Path.GetFullPath(configPath);
+                var configPath = GetSharedConfigPath("different-region-registry.properties");
 
                 // 2. Create GSR serializer with different region registry config
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -724,9 +720,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with non-default endpoint
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/non-default-endpoint.properties");
-                configPath = Path.GetFullPath(configPath);
+                var configPath = GetSharedConfigPath("non-default-endpoint.properties");
 
                 // 2. Create GSR serializer with custom endpoint config
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -797,9 +791,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with auto-registration disabled
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/auto-registration-disabled.properties");
-                configPath = Path.GetFullPath(configPath);
+                var configPath = GetSharedConfigPath("auto-registration-disabled.properties");
 
                 // 2. Create GSR serializer with auto-registration disabled
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -839,9 +831,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with short TTL
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/cache-ttl-short.properties");
-                configPath = Path.GetFullPath(configPath);
+                var configPath = GetSharedConfigPath("cache-ttl-short.properties");
 
                 // 2. Create GSR serializer with caching enabled
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -896,9 +886,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with large cache size
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/cache-ttl-short.properties");
-                configPath = Path.GetFullPath(configPath);
+                var configPath = GetSharedConfigPath("cache-ttl-short.properties");
 
                 // 2. Create GSR serializer with large cache
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -962,9 +950,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use config with small cache size (will be overwhelmed)
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/cache-ttl-short.properties");
-                configPath = Path.GetFullPath(configPath);
+                var configPath = GetSharedConfigPath("cache-ttl-short.properties");
 
                 // 2. Create GSR serializer with limited cache
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -1043,9 +1029,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with caching enabled
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/cache-ttl-short.properties");
-                configPath = Path.GetFullPath(configPath);
+                var configPath = GetSharedConfigPath("cache-ttl-short.properties");
 
                 // 2. Create GSR serializer with caching enabled
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -1108,9 +1092,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with caching enabled
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/cache-ttl-short.properties");
-                configPath = Path.GetFullPath(configPath);
+                var configPath = GetSharedConfigPath("cache-ttl-short.properties");
 
                 // 2. Create GSR serializer with caching enabled
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -1186,9 +1168,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with cache disabled
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/cache-disabled.properties");
-                configPath = Path.GetFullPath(configPath);
+                var configPath = GetSharedConfigPath("cache-disabled.properties");
 
                 // 2. Create GSR serializer with cache disabled
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -1259,9 +1239,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with caching enabled
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/cache-ttl-short.properties");
-                configPath = Path.GetFullPath(configPath);
+                var configPath = GetSharedConfigPath("cache-ttl-short.properties");
 
                 // 2. Create GSR serializer with caching enabled
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -1329,9 +1307,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with ZLIB compression enabled
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/zlib-compression-enabled.properties");
-                configPath = Path.GetFullPath(configPath);
+                var configPath = GetSharedConfigPath("zlib-compression-enabled.properties");
 
                 // 2. Create GSR serializer with ZLIB compression
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -1398,9 +1374,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file without compression settings (defaults to no compression)
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/minimal-auto-registration-custom-registry.properties");
-                configPath = Path.GetFullPath(configPath);
+                var configPath = GetSharedConfigPath("minimal-auto-registration-custom-registry.properties");
 
                 // 2. Create GSR serializer with default compression
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -1466,9 +1440,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file without custom user agent (should use default)
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/minimal-auto-registration-custom-registry.properties");
-                configPath = Path.GetFullPath(configPath);
+                var configPath = GetSharedConfigPath("minimal-auto-registration-custom-registry.properties");
 
                 // 2. Create GSR serializer with default user agent
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);
@@ -1521,9 +1493,7 @@ namespace AWSGsrSerDe.Tests.Configuration
             try
             {
                 // 1. Use shared config file with custom user agent
-                var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location)!;
-                var configPath = Path.Combine(assemblyDir, "../../../../../../shared/test/configs/custom-user-agent.properties");
-                configPath = Path.GetFullPath(configPath);
+                var configPath = GetSharedConfigPath("custom-user-agent.properties");
 
                 // 2. Create GSR serializer with custom user agent
                 var serializer = new GlueSchemaRegistryKafkaSerializer(configPath);

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/integ-tests/configuration/ConfigValidationIntegTests.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/integ-tests/configuration/ConfigValidationIntegTests.cs
@@ -1451,8 +1451,7 @@ namespace AWSGsrSerDe.Tests.Configuration
         {
             /* Test default user agent behavior
              * Create config without custom user agent settings
-             * Serialize data and verify default user agent is used
-             * Default should be something like "aws-glue-schema-registry-native-csharp/x.x.x"
+             * Serialize data and verify schema is registered
              * Cleanup - delete auto-registered schema
              */
 
@@ -1483,7 +1482,7 @@ namespace AWSGsrSerDe.Tests.Configuration
 
                 // 6. Verify schema was registered (user agent is used internally for API calls)
                 var schemaRegistered = await WaitForSchemaRegistration(CUSTOM_REGISTRY_NAME, expectedSchemaName);
-                Assert.IsTrue(schemaRegistered, "Schema should have been registered with default user agent");
+                Assert.IsTrue(schemaRegistered, "Schema has been registered with default user agent (ntive) (behind the scene)");
 
                 Console.WriteLine($"✓ Successfully validated default user agent behavior");
             }
@@ -1506,7 +1505,7 @@ namespace AWSGsrSerDe.Tests.Configuration
         {
             /* Test custom user agent configuration
              * Create config with custom user agent string
-             * Serialize data and verify custom user agent is used
+             * Serialize data successfully when custom user agent is used
              * Custom user agent should be applied to all AWS API calls
              * Cleanup - delete auto-registered schema
              */
@@ -1528,7 +1527,7 @@ namespace AWSGsrSerDe.Tests.Configuration
                 // 3. Create Avro record to serialize
                 var avroRecord = RecordGenerator.GetTestAvroRecord();
 
-                // 4. Serialize the record - should use custom user agent "CustomTestApp/1.0.0"
+                // 4. Serialize the record - should use custom user agent "CustomTestApp/1.0.0" behind the scene
                 var serializedBytes = serializer.Serialize(avroRecord, topicName);
                 Assert.NotNull(serializedBytes, "Serialized bytes should not be null");
                 Assert.That(serializedBytes.Length, Is.GreaterThan(0), "Serialized bytes should not be empty");
@@ -1538,7 +1537,7 @@ namespace AWSGsrSerDe.Tests.Configuration
 
                 // 6. Verify schema was registered (custom user agent is used internally for API calls)
                 var schemaRegistered = await WaitForSchemaRegistration(CUSTOM_REGISTRY_NAME, expectedSchemaName);
-                Assert.IsTrue(schemaRegistered, "Schema should have been registered with custom user agent");
+                Assert.IsTrue(schemaRegistered, "Schema has been registered with custom user agent (behind the scene)");
 
                 Console.WriteLine($"✓ Successfully validated custom user agent configuration");
             }

--- a/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/integ-tests/configuration/ConfigValidationIntegTests.cs
+++ b/native-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe.Tests/integ-tests/configuration/ConfigValidationIntegTests.cs
@@ -1092,7 +1092,7 @@ namespace AWSGsrSerDe.Tests.Configuration
         }
 
         [Test]
-        public async Task Constructor_CacheAndNewSchemaVersionSerialize_MakesNewAPICall()
+        public async Task Constructor_CacheAndNewSchemaVersionSerialize_DoesNotMakesNewAPICall()
         {
             /* Test cache behavior with new schema version
              * Create serializer, serialize schema, register new version manually, serialize again
@@ -1146,7 +1146,11 @@ namespace AWSGsrSerDe.Tests.Configuration
                 var serializedBytes2 = serializer.Serialize(avroRecord, topicName);
                 Assert.NotNull(serializedBytes2, "Second serialized bytes should not be null");
 
-                // 8. Mark schema for cleanup
+                // 8. Verify bytes are same (although new schema version has different UUID, cache still has old UUID)
+                Assert.That(serializedBytes2, Is.EqualTo(serializedBytes1), "New schema version should have same serialized bytes due to cache being defined on schema definition which has not changed.");
+                Console.WriteLine($"✓ Verified new schema version produces same serialized bytes due to caching");
+
+                // 9. Mark schema for cleanup
                 _schemasToCleanup.Add((CUSTOM_REGISTRY_NAME, expectedSchemaName, DEFAULT_REGION));
 
                 Console.WriteLine($"✓ Successfully validated cache behavior with new schema version");

--- a/native-schema-registry/shared/test/configs/auto-registration-disabled.properties
+++ b/native-schema-registry/shared/test/configs/auto-registration-disabled.properties
@@ -1,0 +1,5 @@
+# Expected behavior: Should throw exception when auto-registration is disabled and schema doesn't exist
+# This config disables auto-registration, so GSR should fail when encountering new schemas
+region=us-east-1
+registry.name=native-test-registry
+schemaAutoRegistrationEnabled=false

--- a/native-schema-registry/shared/test/configs/cache-disabled.properties
+++ b/native-schema-registry/shared/test/configs/cache-disabled.properties
@@ -1,0 +1,6 @@
+# Expected behavior: Should always make new API calls when cache is disabled
+# This config disables caching completely
+region=us-east-1
+registry.name=native-test-registry
+schemaAutoRegistrationEnabled=true
+cacheSize=0

--- a/native-schema-registry/shared/test/configs/cache-ttl-short.properties
+++ b/native-schema-registry/shared/test/configs/cache-ttl-short.properties
@@ -1,0 +1,7 @@
+# Expected behavior: Cache should expire quickly and make new API calls
+# This config sets a very short cache TTL for testing cache expiry behavior
+region=us-east-1
+registry.name=native-test-registry
+schemaAutoRegistrationEnabled=true
+cacheSize=100
+timeToLiveMillis=1000

--- a/native-schema-registry/shared/test/configs/custom-user-agent.properties
+++ b/native-schema-registry/shared/test/configs/custom-user-agent.properties
@@ -1,0 +1,6 @@
+# Expected behavior: Should use custom user agent string from config
+# This config sets a custom user agent string
+region=us-east-1
+registry.name=native-test-registry
+schemaAutoRegistrationEnabled=true
+userAgentApp=CustomTestApp/1.0.0

--- a/native-schema-registry/shared/test/configs/different-region-registry.properties
+++ b/native-schema-registry/shared/test/configs/different-region-registry.properties
@@ -1,0 +1,5 @@
+# Expected behavior: Should throw exception when trying to access registry in different region
+# This config tries to access a registry in us-west-2 while client is configured for us-east-1
+region=us-east-1
+registry.name=us-west-2-registry
+schemaAutoRegistrationEnabled=true

--- a/native-schema-registry/shared/test/configs/inexistent-registry.properties
+++ b/native-schema-registry/shared/test/configs/inexistent-registry.properties
@@ -1,0 +1,5 @@
+# Expected behavior: Should throw exception when trying to access non-existent registry
+# This config references a registry that doesn't exist, so GSR call should fail
+region=us-east-1
+registry.name=non-existent-registry-12345
+schemaAutoRegistrationEnabled=true

--- a/native-schema-registry/shared/test/configs/insufficient-iam-permissions.properties
+++ b/native-schema-registry/shared/test/configs/insufficient-iam-permissions.properties
@@ -1,0 +1,5 @@
+# Expected behavior: Should throw exception when IAM permissions are insufficient
+# This config uses valid settings but assumes insufficient IAM permissions for Glue operations
+region=us-east-1
+registry.name=native-test-registry
+schemaAutoRegistrationEnabled=true

--- a/native-schema-registry/shared/test/configs/invalid-role-to-assume.properties
+++ b/native-schema-registry/shared/test/configs/invalid-role-to-assume.properties
@@ -1,0 +1,6 @@
+# Expected behavior: Should throw exception when trying to assume invalid/non-existent role
+# This config references a role that doesn't exist or cannot be assumed
+region=us-east-1
+registry.name=native-test-registry
+schemaAutoRegistrationEnabled=true
+roleToAssume=arn:aws:iam::123456789012:role/NonExistentRole

--- a/native-schema-registry/shared/test/configs/non-default-endpoint.properties
+++ b/native-schema-registry/shared/test/configs/non-default-endpoint.properties
@@ -1,6 +1,6 @@
 # Expected behavior: Should successfully register schema using non-default endpoint
 # This config uses a custom endpoint URL for Glue Schema Registry
-region=us-east-1
+region=us-east-2
 registry.name=native-test-registry
 schemaAutoRegistrationEnabled=true
-endpoint=https://glue.us-east-1.amazonaws.com
+endpoint=https://glue.us-east-2.amazonaws.com

--- a/native-schema-registry/shared/test/configs/non-default-endpoint.properties
+++ b/native-schema-registry/shared/test/configs/non-default-endpoint.properties
@@ -1,0 +1,6 @@
+# Expected behavior: Should successfully register schema using non-default endpoint
+# This config uses a custom endpoint URL for Glue Schema Registry
+region=us-east-1
+registry.name=native-test-registry
+schemaAutoRegistrationEnabled=true
+endpoint=https://glue.us-east-1.amazonaws.com

--- a/native-schema-registry/shared/test/configs/zlib-compression-enabled.properties
+++ b/native-schema-registry/shared/test/configs/zlib-compression-enabled.properties
@@ -1,0 +1,6 @@
+# Expected behavior: Should compress data using ZLIB and set compression byte
+# This config enables ZLIB compression for serialized data
+region=us-east-1
+registry.name=native-test-registry
+schemaAutoRegistrationEnabled=true
+compressionType=ZLIB

--- a/native-schema-registry/shared/test/configs/zlib-compression-enabled.properties
+++ b/native-schema-registry/shared/test/configs/zlib-compression-enabled.properties
@@ -3,4 +3,4 @@
 region=us-east-1
 registry.name=native-test-registry
 schemaAutoRegistrationEnabled=true
-compressionType=ZLIB
+compression=ZLIB


### PR DESCRIPTION
# Description of changes:
This change adds integration tests for the configuration options in CSharp focusing on caching, IAM, user agent changes and bad configuration settings.

| Category | Scenario |
|----------|----------|
| Auth | Invalid IAM role ARN |
| Features | Compression settings validation |
| Caching | Cache population on first schema access |
| Caching | Cache hit on subsequent access |
| Caching | Cache miss for different schema |
| Caching | TTL-based cache eviction |
| Caching | LRU cache eviction |
| Caching | Cache disabled configuration |
| Compression | ZLIB compression enabled |
| Compression | Compression disabled |
| Auto-Registration | Auto-register new schemas |
| Auto-Registration | Auto-registration disabled |
| Versioning | Get existing schema |
| Versioning | Latest schema version retrieval |
| Auto-Registration | Auto-register new schema version of existing schema |
| UserAgent | Confirm that auto registration works with custom UserAgent attribute |
| UserAgent | Confirm that auto registration works with default UserAgent attribute |


<img width="1075" height="144" alt="image" src="https://github.com/user-attachments/assets/3f3c5476-b4a9-4f90-a98f-7c20404e0b95" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
