### PR TITLE
Update default role session name to be more descriptive

### DIFF
--- a/native-schema-registry/src/main/java/com/amazonaws/services/schemaregistry/config/NativeGlueSchemaRegistryConfiguration.java
+++ b/native-schema-registry/src/main/java/com/amazonaws/services/schemaregistry/config/NativeGlueSchemaRegistryConfiguration.java
@@ -45,7 +45,7 @@ public class NativeGlueSchemaRegistryConfiguration extends GlueSchemaRegistryCon
     private void validateAndSetRoleConfiguration(Map<String, ?> configs) {
         if (configs.containsKey("roleToAssume")) {
             this.roleToAssume = (String) configs.get("roleToAssume");
-            this.roleSessionName = "native";
+            this.roleSessionName = "native-glue-schema-registry";
         }
         if (configs.containsKey("roleSessionName")) {
             this.roleSessionName = (String) configs.get("roleSessionName"); // this will override the default session

--- a/native-schema-registry/test/java/com/amazonaws/services/schemaregistry/config/NativeGlueSchemaRegistryConfigurationTest.java
+++ b/native-schema-registry/test/java/com/amazonaws/services/schemaregistry/config/NativeGlueSchemaRegistryConfigurationTest.java
@@ -22,7 +22,7 @@ class NativeGlueSchemaRegistryConfigurationTest {
     private static final String ROLE_ARN_VALUE = "arn:aws:iam::123456789012:role/TestRole";
     private static final String DEFAULT_SESSION_NAME = "native-glue-schema-registry";
     private static final String CUSTOM_SESSION_NAME = "custom-session-name";
-    private static final String DEFAULT_USER_AGENT_APP = "native-glue-schema-registry";
+    private static final String DEFAULT_USER_AGENT_APP = "native";
     private static final String CUSTOM_USER_AGENT_APP = "custom-user-agent-app";
 
     @Test


### PR DESCRIPTION
This pull request updates the default values for session name and user agent application in the native Glue Schema Registry configuration and its tests. The main focus is to ensure consistency between the configuration and its corresponding test cases.

Configuration update:

* Changed the default value of `roleSessionName` to `"native-glue-schema-registry"` when a role is assumed in `NativeGlueSchemaRegistryConfiguration.java` to better reflect the application's identity.

Test update:

* Updated the test constant `DEFAULT_USER_AGENT_APP` in `NativeGlueSchemaRegistryConfigurationTest.java` to `"native"` to align with the actual default value used in the application.