### PR TITLE
Java 17 LTS build compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -391,6 +391,13 @@
                     <source>1.8</source>
                     <target>1.8</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Added `annotationProcessorPaths` to еру configuration of `maven-compiler-plugin` to ensure successful build of [aws-glue-schema-registry](https://github.com/awslabs/aws-glue-schema-registry) using Java 17 LTS


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
