### PR TITLE
WF fix | Install libssh-dev for ubuntu OS

### DIFF
--- a/.github/workflows/build-csharp.yml
+++ b/.github/workflows/build-csharp.yml
@@ -83,7 +83,7 @@ jobs:
             clang_tools: "clang-tools clang-tidy"
             pcre_dev: "libpcre2-dev"
             cpp_compiler: "g++"
-            extra_packages: "zlib1g-dev"
+            extra_packages: "zlib1g-dev libssh-dev"
             dotnet_setup: |
               wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
               dpkg -i packages-microsoft-prod.deb


### PR DESCRIPTION
*Issue #, if available:*
WF fails for ubuntu

*Description of changes:*
WF fix | Install libssh-dev for ubuntu OS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
