### PR TITLE
Fix commons compress version to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
+                <version>1.28.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
*Issue #, if available:*
Commons compress version is not fixed leading to below error

```
[ERROR] Internal error: org.apache.maven.artifact.InvalidArtifactRTException: For artifact {org.apache.commons:commons-compress:null:jar}: The version cannot be empty. -> [Help 1]
org.apache.maven.InternalErrorException: Internal error: org.apache.maven.artifact.InvalidArtifactRTException: For artifact {org.apache.commons:commons-compress:null:jar}: The version cannot be empty.
```

*Description of changes:*
Specifies the version of commons-compress to latest: 1.28.0 (which has no vulnerabilities)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
