### PR TITLE
Update README to reference AWS Connectors

### DIFF
--- a/avro-flink-serde/README.md
+++ b/avro-flink-serde/README.md
@@ -1,6 +1,5 @@
 ## This module is not recommended
-Please check out [Apache Flink](https://github.com/apache/flink) 
-repository for the latest support: [Avro SerializationSchema and DeserializationSchema](https://github.com/apache/flink/tree/master/flink-formats/flink-avro-glue-schema-registry) and [JSON SerializationSchema and Deserialization](https://github.com/apache/flink/tree/master/flink-formats/flink-json-glue-schema-registry). Protobuf integration will be followed up soon.
+Please check out [Apache Flink AWS Connectors](https://github.com/apache/flink-connector-aws) repository for the latest support: [Avro SerializationSchema and DeserializationSchema](https://github.com/apache/flink-connector-aws/tree/main/flink-formats-aws/flink-avro-glue-schema-registry) and [JSON SerializationSchema and Deserialization](https://github.com/apache/flink-connector-aws/tree/main/flink-formats-aws/flink-json-glue-schema-registry). Protobuf integration will be followed up soon.
 
 ## Instructions
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

GlueSchemaRegistry was moved from apache/flink to apache/flink-aws-connectors with following PR. 

https://github.com/apache/flink/pull/21964
https://github.com/apache/flink/pull/21969

This PR will update the doc to point the latest location. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
