### PR TITLE
[Java] Remove php_generic_services usage for protobuf 4.x compatibility

### DIFF
--- a/multilang-schema-registry/shared/test/protos/TestOrderingSyntax3Options.proto
+++ b/multilang-schema-registry/shared/test/protos/TestOrderingSyntax3Options.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package com.amazonaws.services.schemaregistry.utils.apicurio.syntax3.options;
 
-option php_generic_services = true;
 option php_class_prefix = "Example";
 option php_metadata_namespace = "ExampleOptionsSyntax3";
 option php_namespace = "com.amazonaws.services.schemaregistry.utils.apicurio.syntax3.options.example";

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/apicurio/FileDescriptorUtils.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/utils/apicurio/FileDescriptorUtils.java
@@ -79,7 +79,6 @@ public class FileDescriptorUtils {
     private static final String OBJC_CLASS_PREFIX_OPTION = "objc_class_prefix";
     private static final String OPTIMIZE_FOR_OPTION = "optimize_for";
     private static final String PHP_CLASS_PREFIX_OPTION = "php_class_prefix";
-    private static final String PHP_GENERIC_SERVICES_OPTION = "php_generic_services";
     private static final String PHP_METADATA_NAMESPACE_OPTION = "php_metadata_namespace";
     private static final String PHP_NAMESPACE_OPTION = "php_namespace";
     private static final String PY_GENERIC_SERVICES_OPTION = "py_generic_services";
@@ -271,12 +270,6 @@ public class FileDescriptorUtils {
         String objcClassPrefix = findOptionString(OBJC_CLASS_PREFIX_OPTION, element.getOptions());
         if (objcClassPrefix != null) {
             FileOptions options = FileOptions.newBuilder().setObjcClassPrefix(objcClassPrefix).build();
-            schema.mergeOptions(options);
-        }
-
-        Boolean phpGenericServices= findOptionBoolean(PHP_GENERIC_SERVICES_OPTION, element.getOptions());
-        if (phpGenericServices != null) {
-            FileOptions options = FileOptions.newBuilder().setPhpGenericServices(phpGenericServices).build();
             schema.mergeOptions(options);
         }
 
@@ -764,10 +757,6 @@ public class FileDescriptorUtils {
         }
         if (file.getOptions().hasPhpClassPrefix()) {
             OptionElement option = new OptionElement(PHP_CLASS_PREFIX_OPTION, stringKind, file.getOptions().getPhpClassPrefix(), false);
-            options.add(option);
-        }
-        if (file.getOptions().hasPhpGenericServices()) {
-            OptionElement option = new OptionElement(PHP_GENERIC_SERVICES_OPTION, booleanKind, file.getOptions().getPhpGenericServices(), false);
             options.add(option);
         }
         if (file.getOptions().hasPhpMetadataNamespace()) {

--- a/serializer-deserializer/src/test/proto/TestOrderingSyntax3Options.proto
+++ b/serializer-deserializer/src/test/proto/TestOrderingSyntax3Options.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package com.amazonaws.services.schemaregistry.utils.apicurio.syntax3.options;
 
-option php_generic_services = true;
 option php_class_prefix = "Example";
 option php_metadata_namespace = "ExampleOptionsSyntax3";
 option php_namespace = "com.amazonaws.services.schemaregistry.utils.apicurio.syntax3.options.example";


### PR DESCRIPTION
*Issue #, if available:* Fixes #491

*Description of changes:*

Removes all references to `php_generic_services` from `FileDescriptorUtils.java` and test proto files.

This option was removed from protobuf's `FileOptions` in protobuf 4.x (field 42 is now reserved), causing `UnresolvedMethod` errors at GraalVM native image build time with Quarkus 3.29+ which enforces protobuf-java >= 4.32.1.

The option was never functional (PHP protobuf never supported generic services), so removing it has no impact on behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.