### PR TITLE
[Java] Remove AWS SDK v1 STS dependency from serializer-deserializer

### DIFF
--- a/serializer-deserializer/pom.xml
+++ b/serializer-deserializer/pom.xml
@@ -61,11 +61,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sts</artifactId>
-            <version>${aws.sdk.v1.version}</version>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
             <version>${aws.sdk.v2.version}</version>

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/GlueSchemaRegistryKafkaDeserializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/GlueSchemaRegistryKafkaDeserializer.java
@@ -61,9 +61,9 @@ public class GlueSchemaRegistryKafkaDeserializer implements Deserializer<Object>
     }
 
     /**
-     * Constructor accepting AWSCredentialsProvider.
+     * Constructor accepting AwsCredentialsProvider.
      *
-     * @param credentialProvider AWSCredentialsProvider instance.
+     * @param credentialProvider AwsCredentialsProvider instance.
      */
     public GlueSchemaRegistryKafkaDeserializer(AwsCredentialsProvider credentialProvider,
                                                Map<String, ?> configs) {

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/avro/AWSKafkaAvroDeserializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/avro/AWSKafkaAvroDeserializer.java
@@ -63,9 +63,9 @@ public class AWSKafkaAvroDeserializer implements Deserializer<Object> {
     }
 
     /**
-     * Constructor accepting AWSCredentialsProvider.
+     * Constructor accepting AwsCredentialsProvider.
      *
-     * @param credentialProvider AWSCredentialsProvider instance.
+     * @param credentialProvider AwsCredentialsProvider instance.
      */
     public AWSKafkaAvroDeserializer(AwsCredentialsProvider credentialProvider, Map<String, ?> configs) {
         this.credentialProvider = credentialProvider;

--- a/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/GlueSchemaRegistryKafkaDeserializerTest.java
+++ b/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/GlueSchemaRegistryKafkaDeserializerTest.java
@@ -61,7 +61,7 @@ public class GlueSchemaRegistryKafkaDeserializerTest {
         GlueSchemaRegistryKafkaDeserializer glueSchemaRegistryKafkaDeserializer1 = new GlueSchemaRegistryKafkaDeserializer();
         assertNotNull(glueSchemaRegistryKafkaDeserializer1.getCredentialProvider());
 
-        // Test create with AWSCredentialsProvider constructor
+        // Test create with AwsCredentialsProvider constructor
         GlueSchemaRegistryKafkaDeserializer glueSchemaRegistryKafkaDeserializer2 = new GlueSchemaRegistryKafkaDeserializer(this.mockCredProvider,
                 configs);
         assertNotNull(glueSchemaRegistryKafkaDeserializer2.getCredentialProvider());

--- a/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/avro/AWSKafkaAvroDeserializerTest.java
+++ b/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/avro/AWSKafkaAvroDeserializerTest.java
@@ -66,7 +66,7 @@ public class AWSKafkaAvroDeserializerTest {
         AWSKafkaAvroDeserializer awsKafkaAvroDeserializer1 = new AWSKafkaAvroDeserializer();
         assertNotNull(awsKafkaAvroDeserializer1.getCredentialProvider());
 
-        // Test create with AWSCredentialsProvider constructor
+        // Test create with AwsCredentialsProvider constructor
         AWSKafkaAvroDeserializer awsKafkaAvroDeserializer2 = new AWSKafkaAvroDeserializer(this.mockCredProvider,
                 configs);
         assertNotNull(awsKafkaAvroDeserializer2.getCredentialProvider());


### PR DESCRIPTION
*Issue #, if available:* #500

*Description of changes:*

Remove the `com.amazonaws:aws-java-sdk-sts` (AWS SDK v1) dependency from the `serializer-deserializer` module. The v2 equivalent `software.amazon.awssdk:sts` is already declared and no v1 STS classes are used in source code.

Also updates Javadoc comments referencing the v1 class name `AWSCredentialsProvider` to the v2 name `AwsCredentialsProvider`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.