### PR TITLE
[Java] Remove AWS SDK v1 STS dependency from multilang-schema-registry

### DIFF
--- a/multilang-schema-registry/pom.xml
+++ b/multilang-schema-registry/pom.xml
@@ -67,12 +67,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sts</artifactId>
-             <version>${aws.sdk.v1.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
              <version>${aws.sdk.v2.version}</version>


### PR DESCRIPTION
*Issue #, if available:* #500

*Description of changes:*

Remove the `com.amazonaws:aws-java-sdk-sts` (AWS SDK v1) dependency from the `multilang-schema-registry` module. The v2 equivalent `software.amazon.awssdk:sts` is already declared and no v1 STS classes are used in source code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.