### PR TITLE
[Java] Migrate integration tests region resolution from SDK v1 to v2

### DIFF
--- a/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/properties/GlueSchemaRegistryConnectionProperties.java
+++ b/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/properties/GlueSchemaRegistryConnectionProperties.java
@@ -13,10 +13,19 @@
  * limitations under the License.
  */
 package com.amazonaws.services.schemaregistry.integrationtests.properties;
-import com.amazonaws.regions.Regions;
+
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
 public interface GlueSchemaRegistryConnectionProperties {
     // Glue Service Endpoint
-    String REGION = Regions.getCurrentRegion() == null ? "us-east-2" : Regions.getCurrentRegion().getName().toLowerCase();
+    String REGION = resolveRegion();
     String ENDPOINT = String.format("https://glue.%s.amazonaws.com", REGION);
+
+    static String resolveRegion() {
+        try {
+            return new DefaultAwsRegionProviderChain().getRegion().id();
+        } catch (Exception e) {
+            return "us-east-2";
+        }
+    }
 }

--- a/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/properties/GlueSchemaRegistryConnectionProperties.java
+++ b/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/properties/GlueSchemaRegistryConnectionProperties.java
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.services.schemaregistry.integrationtests.properties;
 
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
 public interface GlueSchemaRegistryConnectionProperties {
@@ -24,7 +25,7 @@ public interface GlueSchemaRegistryConnectionProperties {
     static String resolveRegion() {
         try {
             return new DefaultAwsRegionProviderChain().getRegion().id();
-        } catch (Exception e) {
+        } catch (SdkClientException e) {
             return "us-east-2";
         }
     }


### PR DESCRIPTION
*Issue #, if available:* #500

*Description of changes:*

Replace the use of `com.amazonaws.regions.Regions` (AWS SDK v1) with `software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain` (v2) in `GlueSchemaRegistryConnectionProperties.java` for region resolution in integration tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.