### PR TITLE
[Java] Remove AWS SDK v1 version property and dependency management from parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <glue.schema.registry.groupId>software.amazon.glue</glue.schema.registry.groupId>
         <aws.sdk.v2.version>2.32.25</aws.sdk.v2.version>
-        <aws.sdk.v1.version>1.12.782</aws.sdk.v1.version>
         <kafka.scala.version>2.12</kafka.scala.version>
         <kafka.version>3.6.1</kafka.version>
         <avro.version>1.11.4</avro.version>
@@ -274,11 +273,6 @@
                 <groupId>com.github.erosb</groupId>
                 <artifactId>everit-json-schema</artifactId>
                 <version>${everit.json.schema.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-kinesis</artifactId>
-                <version>${aws.sdk.v1.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
*Issue #, if available:* Closes #500

*Description of changes:*

Final cleanup to complete the removal of AWS SDK v1 references:
- Remove the `aws.sdk.v1.version` property from the parent POM
- Remove the `com.amazonaws:aws-java-sdk-kinesis` dependency management entry

All modules have been migrated to AWS SDK v2 in the preceding PRs.

**Requires #503, #504, #505, #506, and #508 to be merged first.**

This PR chain (#503 → #504 → #505 → #506 → #508 → #507) also addresses #274 (AWS SDK v2 upgrade plans) and supersedes #338 which partially addressed the same goal.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.