### PR TITLE
[Java] Upgrade Kinesis Producer Library from 0.x to 1.x

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -93,14 +93,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-	    <artifactId>amazon-kinesis-producer</artifactId>
-	    <exclusions>
-       	        <exclusion>
-		    <groupId>software.amazon.ion</groupId>
-		    <artifactId>ion-java</artifactId>
-	 	</exclusion>
-	    </exclusions>
+            <groupId>software.amazon.kinesis</groupId>
+            <artifactId>amazon-kinesis-producer</artifactId>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kinesis/GlueSchemaRegistryKinesisIntegrationTest.java
+++ b/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kinesis/GlueSchemaRegistryKinesisIntegrationTest.java
@@ -17,9 +17,9 @@ package com.amazonaws.services.schemaregistry.integrationtests.kinesis;
 
 import cloud.localstack.Constants;
 import cloud.localstack.ServiceName;
-import com.amazonaws.services.kinesis.producer.KinesisProducer;
-import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
-import com.amazonaws.services.kinesis.producer.UserRecordResult;
+import software.amazon.kinesis.producer.KinesisProducer;
+import software.amazon.kinesis.producer.KinesisProducerConfiguration;
+import software.amazon.kinesis.producer.UserRecordResult;
 import com.amazonaws.services.schemaregistry.common.GlueSchemaRegistryDataFormatDeserializer;
 import com.amazonaws.services.schemaregistry.common.GlueSchemaRegistryDataFormatSerializer;
 import com.amazonaws.services.schemaregistry.common.Schema;

--- a/pom.xml
+++ b/pom.xml
@@ -107,8 +107,7 @@
         <hamcrest.version>1.1</hamcrest.version>
         <!--  LATEST KCL Does not work with LocalStack yet, remove once new version works -->
         <kinesis.client.version>2.2.9</kinesis.client.version>
-        <!--  LATEST KPL will cause integration test failure in Linux environment, update once we find a way to address the issue -->
-        <kinesis.producer.version>0.15.8</kinesis.producer.version>
+        <kinesis.producer.version>1.0.7</kinesis.producer.version>
         <junit.platform.commons.version>1.6.2</junit.platform.commons.version>
         <junit.platform.surefire.version>1.3.2</junit.platform.surefire.version>
         <guava.version>32.0.0-jre</guava.version>
@@ -303,16 +302,10 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.amazonaws</groupId>
+                <groupId>software.amazon.kinesis</groupId>
                 <artifactId>amazon-kinesis-producer</artifactId>
                 <version>${kinesis.producer.version}</version>
                 <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                    <groupId>software.amazon.ion</groupId>
-                    <artifactId>ion-java</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.awaitility</groupId>


### PR DESCRIPTION
*Issue #, if available:* Fixes #509

*Description of changes:*

Upgrade the Kinesis Producer Library (KPL) from `com.amazonaws:amazon-kinesis-producer:0.15.8` to `software.amazon.kinesis:amazon-kinesis-producer:1.0.7`.

KPL 0.x is reaching end of life (see [KPL README](https://github.com/awslabs/amazon-kinesis-producer/blob/master/README.md)). KPL 1.x uses AWS SDK for Java v2 instead of v1.

Changes:
- Updated groupId from `com.amazonaws` to `software.amazon.kinesis` in parent POM and integration-tests POM
- Updated version from `0.15.8` to `1.0.7`
- Updated imports from `com.amazonaws.services.kinesis.producer.*` to `software.amazon.kinesis.producer.*`
- Removed `ion-java` exclusion (no longer needed in 1.x)

Migration guide: https://docs.aws.amazon.com/streams/latest/dev/kpl-migration-1x.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.