### PR TITLE
[Java] Add JDK 25 support

### DIFF
--- a/.github/workflows/MavenCI.yml
+++ b/.github/workflows/MavenCI.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
-        java-version: ['8', '11', '17']
+        java-version: ['8', '11', '17', '21', '25']
 
     steps:
     - uses: actions/checkout@v2

--- a/pom.xml
+++ b/pom.xml
@@ -101,9 +101,8 @@
         <log4j.version>2.17.1</log4j.version>
         <jupiter.version>5.6.3</jupiter.version>
         <mockito.version>3.3.3</mockito.version>
-        <lombok.version>1.18.30</lombok.version>
+        <lombok.version>1.18.42</lombok.version>
         <mockito.version>3.6.28</mockito.version>
-        <lombok.utils.version>1.18.12</lombok.utils.version>
         <hamcrest.version>1.1</hamcrest.version>
         <!--  LATEST KCL Does not work with LocalStack yet, remove once new version works -->
         <kinesis.client.version>2.2.9</kinesis.client.version>
@@ -416,11 +415,18 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.14.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
*Issue #, if available:* Fixes #511, Fixes #378

*Description of changes:*

Lombok 1.18.30 does not support JDK 25, causing compilation failures (`cannot find symbol` for Lombok-generated methods). This PR:

- Upgrades Lombok from 1.18.30 to 1.18.42 (adds JDK 25 support, [changelog](https://projectlombok.org/changelog))
- Upgrades maven-compiler-plugin from 3.11.0 to 3.14.0
- Adds explicit `annotationProcessorPaths` for Lombok in the parent POM compiler plugin configuration, which is required for annotation processing to work correctly with recent JDKs
- Removes unused `lombok.utils.version` property

The Java source/target version (1.8) is unchanged.

All 2000+ tests pass with these changes on JDK 25.

Supersedes #477 and #363, which address the same underlying Lombok annotation processing issue on modern JDKs.

Also addresses #200 — the README states "Java > 1.8 and < Java 15", but with this fix the project builds and tests pass on JDK 8, 11, 17, 21, and 25.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.