### PR TITLE
[Java] Update MavenCI workflow: upgrade actions and add JDK 21

### DIFF
--- a/.github/workflows/MavenCI.yml
+++ b/.github/workflows/MavenCI.yml
@@ -5,9 +5,6 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  release:
-    branches: [ master ]
-    types: [ created ]
 
 jobs:
   build:
@@ -19,15 +16,16 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
-        java-version: ['8', '11', '17']
+        java-version: ['8', '11', '17', '21']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up JDK ${{ matrix.java-version }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java-version }}
+        distribution: 'corretto'
 
     - name: Cache Maven packages
       uses: actions/cache@v4
@@ -36,8 +34,5 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
 
-    - name: Clean, build and install
-      run: mvn --file pom.xml clean install
-
-    - name: Build package
-      run: mvn -B package --file pom.xml
+    - name: Build and test
+      run: mvn --file pom.xml clean verify


### PR DESCRIPTION
## Summary

Updates the `MavenCI` GitHub Actions workflow to use current action versions and expand the Java test matrix.

## Changes

- Upgrade `actions/checkout` from v2 to v4
- Upgrade `actions/setup-java` from v1 to v4 (adds required `distribution` parameter)
- Use Amazon Corretto as Java distribution
- Add JDK 21 to the test matrix (8, 11, 17, 21)
- Replace two-step `clean install` + `package` with a single `clean verify` (runs compile, test and package in one pass)
- Remove `release` trigger (releases should use a dedicated publish workflow)
