### PR TITLE
[Java] Fix NoClassDefFoundError: lombok/Lombok at runtime

### DIFF
--- a/avro-flink-serde/src/main/java/com/amazonaws/services/schemaregistry/flink/avro/GlueSchemaRegistryAvroSerializationSchema.java
+++ b/avro-flink-serde/src/main/java/com/amazonaws/services/schemaregistry/flink/avro/GlueSchemaRegistryAvroSerializationSchema.java
@@ -16,7 +16,6 @@
 package com.amazonaws.services.schemaregistry.flink.avro;
 
 import com.google.common.annotations.VisibleForTesting;
-import lombok.SneakyThrows;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.Encoder;
@@ -26,6 +25,8 @@ import org.apache.flink.formats.avro.SchemaCoder;
 
 import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Map;
 
 /**
@@ -93,7 +94,6 @@ public class GlueSchemaRegistryAvroSerializationSchema<T> extends RegistryAvroSe
      * @param object The incoming element to be serialized
      * @return The serialized bytes.
      */
-    @SneakyThrows
     @Override
     public byte[] serialize(T object) {
         checkAvroInitialized();
@@ -101,14 +101,18 @@ public class GlueSchemaRegistryAvroSerializationSchema<T> extends RegistryAvroSe
         if (object == null) {
             return null;
         } else {
-            ByteArrayOutputStream outputStream = getOutputStream();
-            outputStream.reset();
-            Encoder encoder = getEncoder();
-            getDatumWriter().write(object, encoder);
-            schemaCoder.writeSchema(getSchema(), outputStream);
-            encoder.flush();
+            try {
+                ByteArrayOutputStream outputStream = getOutputStream();
+                outputStream.reset();
+                Encoder encoder = getEncoder();
+                getDatumWriter().write(object, encoder);
+                schemaCoder.writeSchema(getSchema(), outputStream);
+                encoder.flush();
 
-            return outputStream.toByteArray();
+                return outputStream.toByteArray();
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to serialize Avro record", e);
+            }
         }
     }
 }

--- a/common/src/main/java/com/amazonaws/services/schemaregistry/common/SchemaByDefinitionFetcher.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/common/SchemaByDefinitionFetcher.java
@@ -9,7 +9,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 
 import java.util.Map;
 import java.util.UUID;
@@ -61,7 +60,6 @@ public class SchemaByDefinitionFetcher {
      * @return Schema Version ID
      * @throws AWSSchemaRegistryException on any error while fetching the schema version ID
      */
-    @SneakyThrows
     public UUID getORRegisterSchemaVersionId(
         @NonNull String schemaDefinition,
         @NonNull String schemaName,

--- a/protobuf-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/protobuf/fromconnectschema/ConnectSchemaToProtobufSchemaConverter.java
+++ b/protobuf-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/protobuf/fromconnectschema/ConnectSchemaToProtobufSchemaConverter.java
@@ -19,8 +19,8 @@ import com.amazonaws.services.schemaregistry.utils.apicurio.FileDescriptorUtils;
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Descriptors;
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.DataException;
 
 /**
  * Converts Kafka Connect schemas to Protobuf3 schemas.
@@ -83,8 +83,11 @@ public class ConnectSchemaToProtobufSchemaConverter {
         return messageDescriptorProtoBuilder;
     }
 
-    @SneakyThrows
     private Descriptors.FileDescriptor buildFileDescriptor(DescriptorProtos.FileDescriptorProto fileDescriptorProto) {
-        return Descriptors.FileDescriptor.buildFrom(fileDescriptorProto, FileDescriptorUtils.baseDependencies());
+        try {
+            return Descriptors.FileDescriptor.buildFrom(fileDescriptorProto, FileDescriptorUtils.baseDependencies());
+        } catch (Descriptors.DescriptorValidationException e) {
+            throw new DataException("Failed to build Protobuf FileDescriptor", e);
+        }
     }
 }

--- a/protobuf-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/protobuf/toconnectdata/ProtobufDataToConnectDataConverter.java
+++ b/protobuf-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/protobuf/toconnectdata/ProtobufDataToConnectDataConverter.java
@@ -19,9 +19,9 @@ import additionalTypes.Decimals;
 import com.amazonaws.services.schemaregistry.kafkaconnect.protobuf.fromconnectschema.ProtobufSchemaConverterUtils;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.type.TimeOfDay;
-import lombok.SneakyThrows;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -119,24 +119,27 @@ public class ProtobufDataToConnectDataConverter {
         return units.add(fractionalPart);
     }
 
-    @SneakyThrows
     private Object toConnectDataField(Schema schema, Object value) {
-        if (Date.SCHEMA.name().equals(schema.name())) {
-            com.google.type.Date date = com.google.type.Date.parseFrom(((Message) value).toByteArray());
-            return ProtobufSchemaConverterUtils.convertFromGoogleDate(date);
-        }
-        if (Timestamp.SCHEMA.name().equals(schema.name())) {
-            com.google.protobuf.Timestamp timestamp =
-                    com.google.protobuf.Timestamp.parseFrom(((Message) value).toByteArray());
-            return Timestamp.toLogical(schema, Timestamps.toMillis(timestamp));
-        }
-        if (Time.SCHEMA.name().equals(schema.name())) {
-            TimeOfDay time = TimeOfDay.parseFrom(((Message) value).toByteArray());
-            return ProtobufSchemaConverterUtils.convertFromGoogleTime(time);
-        }
-        if (Decimal.schema(DECIMAL_DEFAULT_SCALE).name().equals(schema.name())) {
-            Decimals.Decimal decimal = Decimals.Decimal.parseFrom(((Message) value).toByteArray());
-            return fromDecimalProto(decimal);
+        try {
+            if (Date.SCHEMA.name().equals(schema.name())) {
+                com.google.type.Date date = com.google.type.Date.parseFrom(((Message) value).toByteArray());
+                return ProtobufSchemaConverterUtils.convertFromGoogleDate(date);
+            }
+            if (Timestamp.SCHEMA.name().equals(schema.name())) {
+                com.google.protobuf.Timestamp timestamp =
+                        com.google.protobuf.Timestamp.parseFrom(((Message) value).toByteArray());
+                return Timestamp.toLogical(schema, Timestamps.toMillis(timestamp));
+            }
+            if (Time.SCHEMA.name().equals(schema.name())) {
+                TimeOfDay time = TimeOfDay.parseFrom(((Message) value).toByteArray());
+                return ProtobufSchemaConverterUtils.convertFromGoogleTime(time);
+            }
+            if (Decimal.schema(DECIMAL_DEFAULT_SCALE).name().equals(schema.name())) {
+                Decimals.Decimal decimal = Decimals.Decimal.parseFrom(((Message) value).toByteArray());
+                return fromDecimalProto(decimal);
+            }
+        } catch (InvalidProtocolBufferException e) {
+            throw new DataException("Failed to parse protobuf message for schema: " + schema.name(), e);
         }
         switch (schema.type()) {
             case INT8:

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/GlueSchemaRegistryDeserializerDataParser.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/GlueSchemaRegistryDeserializerDataParser.java
@@ -15,12 +15,13 @@
 package com.amazonaws.services.schemaregistry.deserializers;
 
 import com.amazonaws.services.schemaregistry.common.GlueSchemaRegistryCompressionFactory;
+import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryException;
 import com.amazonaws.services.schemaregistry.exception.GlueSchemaRegistryIncompatibleDataException;
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.UUID;
 
@@ -160,11 +161,14 @@ public final class GlueSchemaRegistryDeserializerDataParser {
         return decompressData(compressionByte, slicedBuffer, dataStart, dataEnd);
     }
 
-    @SneakyThrows
     private byte[] decompressData(Byte compressionByte, ByteBuffer compressedData, int start, int end) {
-        return compressionFactory
-                .getCompressionHandler(compressionByte)
-                .decompress(compressedData.array(), start, end);
+        try {
+            return compressionFactory
+                    .getCompressionHandler(compressionByte)
+                    .decompress(compressedData.array(), start, end);
+        } catch (IOException e) {
+            throw new AWSSchemaRegistryException("Failed to decompress data", e);
+        }
     }
 
     /**

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/GlueSchemaRegistrySerializationFacade.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/GlueSchemaRegistrySerializationFacade.java
@@ -25,7 +25,6 @@ import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryExceptio
 import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import lombok.Builder;
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.glue.model.DataFormat;
@@ -73,7 +72,6 @@ public class GlueSchemaRegistrySerializationFacade {
         this.serializationDataEncoder = new SerializationDataEncoder(this.glueSchemaRegistryConfiguration);
     }
 
-    @SneakyThrows
     public UUID getOrRegisterSchemaVersion(@NonNull AWSSerializerInput serializerInput) {
         String schemaDefinition = serializerInput.getSchemaDefinition();
         String schemaName = serializerInput.getSchemaName();

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/avro/AvroSerializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/avro/AvroSerializer.java
@@ -36,6 +36,7 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificRecord;
 
 import java.io.ByteArrayOutputStream;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Avro serialization helper.
@@ -97,8 +98,8 @@ public class AvroSerializer implements GlueSchemaRegistryDataFormatSerializer {
         try {
             DatumWriterCacheKey datumWriterCacheKey = new DatumWriterCacheKey(schema, AvroRecordType.SPECIFIC_RECORD);
             return datumWriterCache.get(datumWriterCacheKey);
-        } catch (Exception e) {
-            throw new AWSSchemaRegistryException("Failed to get SpecificDatumWriter from cache", e);
+        } catch (ExecutionException e) {
+            throw new AWSSchemaRegistryException("Failed to get SpecificDatumWriter from cache", e.getCause());
         }
     }
 
@@ -106,8 +107,8 @@ public class AvroSerializer implements GlueSchemaRegistryDataFormatSerializer {
         try {
             DatumWriterCacheKey datumWriterCacheKey = new DatumWriterCacheKey(schema, AvroRecordType.GENERIC_RECORD);
             return datumWriterCache.get(datumWriterCacheKey);
-        } catch (Exception e) {
-            throw new AWSSchemaRegistryException("Failed to get GenericDatumWriter from cache", e);
+        } catch (ExecutionException e) {
+            throw new AWSSchemaRegistryException("Failed to get GenericDatumWriter from cache", e.getCause());
         }
     }
 

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/avro/AvroSerializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/serializers/avro/AvroSerializer.java
@@ -26,7 +26,6 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -94,16 +93,22 @@ public class AvroSerializer implements GlueSchemaRegistryDataFormatSerializer {
         }
     }
 
-    @SneakyThrows
     private DatumWriter<Object> getSpecificDatumWriter(Schema schema) {
-        DatumWriterCacheKey datumWriterCacheKey = new DatumWriterCacheKey(schema, AvroRecordType.SPECIFIC_RECORD);
-        return datumWriterCache.get(datumWriterCacheKey);
+        try {
+            DatumWriterCacheKey datumWriterCacheKey = new DatumWriterCacheKey(schema, AvroRecordType.SPECIFIC_RECORD);
+            return datumWriterCache.get(datumWriterCacheKey);
+        } catch (Exception e) {
+            throw new AWSSchemaRegistryException("Failed to get SpecificDatumWriter from cache", e);
+        }
     }
 
-    @SneakyThrows
     private DatumWriter<Object> getGenericDatumWriter(Schema schema) {
-        DatumWriterCacheKey datumWriterCacheKey = new DatumWriterCacheKey(schema, AvroRecordType.GENERIC_RECORD);
-        return datumWriterCache.get(datumWriterCacheKey);
+        try {
+            DatumWriterCacheKey datumWriterCacheKey = new DatumWriterCacheKey(schema, AvroRecordType.GENERIC_RECORD);
+            return datumWriterCache.get(datumWriterCacheKey);
+        } catch (Exception e) {
+            throw new AWSSchemaRegistryException("Failed to get GenericDatumWriter from cache", e);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes #513 — `@SneakyThrows` generates bytecode that calls `Lombok.sneakyThrow()` at runtime, but Lombok is declared with `scope: provided` and is not present in the runtime classpath. This causes `NoClassDefFoundError: lombok/Lombok` when any checked exception is thrown in a `@SneakyThrows`-annotated method.

## Changes

Replaced all `@SneakyThrows` usages in production code (7 files across 4 modules) with explicit try-catch blocks:

- **serializer-deserializer**: `GlueSchemaRegistrySerializationFacade`, `AvroSerializer`, `GlueSchemaRegistryDeserializerDataParser`
- **common**: `SchemaByDefinitionFetcher`
- **avro-flink-serde**: `GlueSchemaRegistryAvroSerializationSchema`
- **protobuf-kafkaconnect-converter**: `ProtobufDataToConnectDataConverter`, `ConnectSchemaToProtobufSchemaConverter`

Checked exceptions are wrapped in the appropriate runtime exception for each context (`AWSSchemaRegistryException`, `UncheckedIOException`, `DataException`).
