### PR TITLE
[Java] Fix BigDecimal conversion error in Avro KafkaConnect converter

### DIFF
--- a/avro-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/avrodata/AvroData.java
+++ b/avro-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/avrodata/AvroData.java
@@ -1389,12 +1389,8 @@ public class AvroData {
                         converted = value;
                     } else if (value instanceof GenericFixed) {
                         converted = ByteBuffer.wrap(((GenericFixed) value).bytes());
-                    } else if (value instanceof BigDecimal) {
-                        BigDecimal decimal = (BigDecimal) value;
-                        int scale = schema.parameters() != null && schema.parameters().containsKey(Decimal.SCALE_FIELD)
-                                ? Integer.parseInt(schema.parameters().get(Decimal.SCALE_FIELD))
-                                : 0;
-                        converted = ByteBuffer.wrap(Decimal.fromLogical(Decimal.schema(scale), decimal));
+                    } else if (value instanceof BigDecimal && Decimal.LOGICAL_NAME.equals(schema.name())) {
+                        converted = ByteBuffer.wrap(Decimal.fromLogical(schema, (BigDecimal) value));
                     } else {
                         throw new DataException("Invalid class for bytes type, expecting byte[] or ByteBuffer "
                                 + "but found " + value.getClass());

--- a/avro-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/avrodata/AvroData.java
+++ b/avro-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/avrodata/AvroData.java
@@ -1389,6 +1389,12 @@ public class AvroData {
                         converted = value;
                     } else if (value instanceof GenericFixed) {
                         converted = ByteBuffer.wrap(((GenericFixed) value).bytes());
+                    } else if (value instanceof BigDecimal) {
+                        BigDecimal decimal = (BigDecimal) value;
+                        int scale = schema.parameters() != null && schema.parameters().containsKey(Decimal.SCALE_FIELD)
+                                ? Integer.parseInt(schema.parameters().get(Decimal.SCALE_FIELD))
+                                : 0;
+                        converted = ByteBuffer.wrap(Decimal.fromLogical(Decimal.schema(scale), decimal));
                     } else {
                         throw new DataException("Invalid class for bytes type, expecting byte[] or ByteBuffer "
                                 + "but found " + value.getClass());

--- a/avro-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/avrodata/AvroDataBigDecimalTest.java
+++ b/avro-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/avrodata/AvroDataBigDecimalTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.schemaregistry.kafkaconnect.avrodata;
+
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AvroDataBigDecimalTest {
+    private AvroData avroData;
+
+    @BeforeEach
+    void setUp() {
+        avroData = new AvroData(2);
+    }
+
+    @Test
+    void testToConnectDataWithBigDecimalValue() {
+        org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.builder().bytesType();
+        avroSchema.addProp(AvroData.AVRO_LOGICAL_TYPE_PROP, AvroData.AVRO_LOGICAL_DECIMAL);
+        avroSchema.addProp("precision", 50);
+        avroSchema.addProp("scale", 2);
+
+        BigDecimal testDecimal = new BigDecimal(new BigInteger("156"), 2);
+
+        SchemaAndValue expected = new SchemaAndValue(
+                Decimal.builder(2).parameter(AvroData.CONNECT_AVRO_DECIMAL_PRECISION_PROP, "50").build(),
+                testDecimal
+        );
+
+        SchemaAndValue actual = avroData.toConnectData(avroSchema, testDecimal);
+
+        assertEquals(expected.schema(), actual.schema());
+        assertEquals(expected.value(), actual.value());
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* Fixes #361

*Description of changes:*

When Avro passes a `BigDecimal` value (from a logical decimal type) to `AvroData.toConnectData()`, the `BYTES` case handler did not recognize `BigDecimal` instances, throwing:

```
DataException: Invalid class for bytes type, expecting byte[] or ByteBuffer but found class java.math.BigDecimal
```

This happens with Avro 1.12+ which can resolve logical decimal types to `BigDecimal` objects instead of raw `ByteBuffer`.

The fix adds a `BigDecimal` branch in the `BYTES` case that converts the value using Kafka Connect's `Decimal.fromLogical()` to produce the expected byte representation.

A JUnit 5 test is included that reproduces the issue and validates the fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.