### PR TITLE
[Java] Remove unused jimfs dependency

### DIFF
--- a/serializer-deserializer/pom.xml
+++ b/serializer-deserializer/pom.xml
@@ -189,11 +189,6 @@
             <artifactId>proto-google-common-protos</artifactId>
             <version>2.7.4</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.jimfs</groupId>
-            <artifactId>jimfs</artifactId>
-            <version>1.1</version>
-        </dependency>
         <!-- Used for Proto assertions in tests -->
         <dependency>
             <groupId>com.google.truth.extensions</groupId>


### PR DESCRIPTION
*Issue #, if available:* Fixes #353

*Description of changes:*

Remove the unused `com.google.jimfs:jimfs` direct dependency from `serializer-deserializer/pom.xml`.

This dependency was left behind after its usages were removed in #230. No code in the project imports any jimfs classes. The library remains available as a transitive dependency (via `wire-compiler`) for the `multilang-schema-registry` GraalVM native-image build, so the `native-image.properties` configuration continues to work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.