### PR TITLE
[Java] Fix NullPointerException in protobuf FieldBuilder for schemas without parameters

### DIFF
--- a/protobuf-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/protobuf/fromconnectschema/FieldBuilder.java
+++ b/protobuf-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/protobuf/fromconnectschema/FieldBuilder.java
@@ -89,7 +89,8 @@ public class FieldBuilder {
                 messageDescriptorProtoBuilder.addNestedType(buildMap(fieldSchema, mapEntryName,
                     fileDescriptorProtoBuilder, messageDescriptorProtoBuilder));
             } else if (Schema.Type.STRUCT.equals(fieldSchema.type())) {
-                if (fieldSchema.parameters().containsKey(PROTOBUF_TYPE)
+                if (fieldSchema.parameters() != null
+                        && fieldSchema.parameters().containsKey(PROTOBUF_TYPE)
                         && fieldSchema.parameters().get(PROTOBUF_TYPE).equals(PROTOBUF_ONEOF_TYPE)) {
                     buildOneof(fieldSchema, fieldName, tagNumber, fileDescriptorProtoBuilder,
                             messageDescriptorProtoBuilder, fieldBuilderMap);
@@ -99,11 +100,13 @@ public class FieldBuilder {
                 // Convert the Struct type schema to a Protobuf message schema
                 DescriptorProtos.DescriptorProto.Builder nestedMessageDescriptorProtoBuilder =
                         DescriptorProtos.DescriptorProto.newBuilder();
-                nestedMessageDescriptorProtoBuilder.setName(getSchemaSimpleName(fieldSchema.name()));
+                String structName = fieldSchema.name() != null ? fieldSchema.name() : fieldName;
+                nestedMessageDescriptorProtoBuilder.setName(getSchemaSimpleName(structName));
                 build(fieldSchema, fileDescriptorProtoBuilder, nestedMessageDescriptorProtoBuilder);
                 // If schema is at parent level, Protobuf message is added as a message type
                 // If schema is not at parent level, Protobuf message is added as a nested type
-                if (isParentLevel(fileDescriptorProtoBuilder.getPackage(), fieldSchema.name())) {
+                if (fieldSchema.name() != null
+                        && isParentLevel(fileDescriptorProtoBuilder.getPackage(), fieldSchema.name())) {
                     fileDescriptorProtoBuilder.addMessageType(nestedMessageDescriptorProtoBuilder);
                 } else {
                     messageDescriptorProtoBuilder.addNestedType(nestedMessageDescriptorProtoBuilder);

--- a/protobuf-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/protobuf/fromconnectschema/FieldBuilder.java
+++ b/protobuf-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/protobuf/fromconnectschema/FieldBuilder.java
@@ -89,9 +89,9 @@ public class FieldBuilder {
                 messageDescriptorProtoBuilder.addNestedType(buildMap(fieldSchema, mapEntryName,
                     fileDescriptorProtoBuilder, messageDescriptorProtoBuilder));
             } else if (Schema.Type.STRUCT.equals(fieldSchema.type())) {
-                if (fieldSchema.parameters() != null
-                        && fieldSchema.parameters().containsKey(PROTOBUF_TYPE)
-                        && fieldSchema.parameters().get(PROTOBUF_TYPE).equals(PROTOBUF_ONEOF_TYPE)) {
+                Map<String, String> fieldParameters = fieldSchema.parameters();
+                if (fieldParameters != null
+                        && PROTOBUF_ONEOF_TYPE.equals(fieldParameters.get(PROTOBUF_TYPE))) {
                     buildOneof(fieldSchema, fieldName, tagNumber, fileDescriptorProtoBuilder,
                             messageDescriptorProtoBuilder, fieldBuilderMap);
                     continue;
@@ -100,7 +100,9 @@ public class FieldBuilder {
                 // Convert the Struct type schema to a Protobuf message schema
                 DescriptorProtos.DescriptorProto.Builder nestedMessageDescriptorProtoBuilder =
                         DescriptorProtos.DescriptorProto.newBuilder();
-                String structName = fieldSchema.name() != null ? fieldSchema.name() : fieldName;
+                String structName = fieldSchema.name() != null
+                        ? fieldSchema.name()
+                        : fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
                 nestedMessageDescriptorProtoBuilder.setName(getSchemaSimpleName(structName));
                 build(fieldSchema, fileDescriptorProtoBuilder, nestedMessageDescriptorProtoBuilder);
                 // If schema is at parent level, Protobuf message is added as a message type
@@ -209,7 +211,15 @@ public class FieldBuilder {
                     + ProtobufSchemaConverterUtils.toMapEntryName(fieldName));
             fieldDescriptorProtoBuilder.setTypeName(typeName);
         } else if (Schema.Type.STRUCT.equals(fieldSchema.type())) {
-            String typeName = getTypeName(fieldSchema.name());
+            String name;
+            if (fieldSchema.name() != null) {
+                name = fieldSchema.name();
+            } else {
+                String simpleName = fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
+                name = fileDescriptorProtoBuilder.getPackage() + "."
+                        + messageDescriptorProtoBuilder.getName() + "." + simpleName;
+            }
+            String typeName = getTypeName(name);
             fieldDescriptorProtoBuilder.setTypeName(typeName);
         }
 

--- a/protobuf-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/protobuf/fromconnectschema/ConnectSchemaToProtobufSchemaConverterTest.java
+++ b/protobuf-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/protobuf/fromconnectschema/ConnectSchemaToProtobufSchemaConverterTest.java
@@ -150,4 +150,24 @@ public class ConnectSchemaToProtobufSchemaConverterTest {
     public void fromConnectSchema_onNullSchema_ThrowsException() {
         assertThrows(IllegalArgumentException.class, () -> CONNECT_SCHEMA_TO_PROTOBUF_SCHEMA_CONVERTER.convert(null));
     }
+
+    @Test
+    public void fromConnectSchema_structWithNullParametersAndName_doesNotThrowNPE() {
+        // Simulate a Debezium-style schema where STRUCT fields have no protobuf
+        // metadata parameters and no schema name
+        SchemaBuilder nestedStructBuilder = new SchemaBuilder(Schema.Type.STRUCT);
+        // No .name() and no .parameter() calls — both will be null
+        nestedStructBuilder.field("innerField", Schema.STRING_SCHEMA);
+        Schema nestedStruct = nestedStructBuilder.build();
+
+        SchemaBuilder parentSchemaBuilder = new SchemaBuilder(Schema.Type.STRUCT);
+        parentSchemaBuilder.name("ParentMessage");
+        parentSchemaBuilder.field("nestedField", nestedStruct);
+        Schema parentSchema = parentSchemaBuilder.build();
+
+        final Descriptors.FileDescriptor protobufSchema =
+                CONNECT_SCHEMA_TO_PROTOBUF_SCHEMA_CONVERTER.convert(parentSchema);
+
+        assertEquals(1, protobufSchema.getMessageTypes().size());
+    }
 }


### PR DESCRIPTION
*Issue #, if available:* Fixes #289

*Description of changes:*

When using Debezium or other Kafka Connect source connectors with `ProtobufSchemaConverter`, a `NullPointerException` is thrown in `FieldBuilder.build()` because `fieldSchema.parameters()` can return `null` for STRUCT-type fields that don't carry protobuf metadata.

This PR adds null guards in two places in `FieldBuilder.java`:
- Check `fieldSchema.parameters() != null` before calling `.containsKey(PROTOBUF_TYPE)` (line 92)
- Check `fieldSchema.name() != null` before passing it to `getSchemaSimpleName()` and `isParentLevel()`, falling back to the field name for unnamed struct schemas

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.