### PR TITLE
[Java] Default avroRecordType to GENERIC_RECORD when not configured

### DIFF
--- a/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
@@ -48,7 +48,7 @@ public class GlueSchemaRegistryConfiguration {
     private String region;
     private long timeToLiveMillis = 24 * 60 * 60 * 1000L;
     private int cacheSize = 200;
-    private AvroRecordType avroRecordType;
+    private AvroRecordType avroRecordType = AvroRecordType.GENERIC_RECORD;
     private ProtobufMessageType protobufMessageType;
     private String registryName;
     private Compatibility compatibilitySetting;

--- a/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
+++ b/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
@@ -197,6 +197,7 @@ public class GlueSchemaRegistryConfigurationTest {
         assertNotNull(serDeConfigs.getTimeToLiveMillis());
         assertNotNull(serDeConfigs.getCompressionType().equals(AWSSchemaRegistryConstants.COMPRESSION.NONE));
         assertNotNull(serDeConfigs.getCompatibilitySetting().equals(Compatibility.NONE));
+        assertEquals(AvroRecordType.GENERIC_RECORD, serDeConfigs.getAvroRecordType());
     }
 
 


### PR DESCRIPTION
*Issue #, if available:* Fixes #128

*Description of changes:*

When `avroRecordType` is not set in the Kafka Connect connector configuration, `GlueSchemaRegistryConfiguration.avroRecordType` is `null`. This null value is passed to `DatumReaderInstance.from()`, which performs a `switch` on it, causing a `NullPointerException` during deserialization.

The fix defaults `avroRecordType` to `GENERIC_RECORD` in `GlueSchemaRegistryConfiguration`, which is the safest default since `GenericDatumReader` works without requiring specific code-generated schema classes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.