### PR TITLE
feat(csharp-demos): Migrate to AWS.Glue.SchemaRegistry NuGet package in the demo project to demonstrate online build + Fix Csharp builds in Actions

### DIFF
--- a/.github/workflows/MavenCI.yml
+++ b/.github/workflows/MavenCI.yml
@@ -22,11 +22,12 @@ jobs:
         java-version: ['8', '11', '17']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up JDK ${{ matrix.java-version }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
+        distribution: 'corretto'
         java-version: ${{ matrix.java-version }}
 
     - name: Cache Maven packages

--- a/.github/workflows/build-csharp.yml
+++ b/.github/workflows/build-csharp.yml
@@ -138,10 +138,10 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Maven 3.9.12
+      - name: Install Maven
         shell: bash
         run: |
-          curl -sSL https://dlcdn.apache.org/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz | tar xz
+          curl -sSL https://archive.apache.org/dist/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz | tar xz
           mv apache-maven-3.9.12 /opt/maven
           echo "MAVEN_HOME=/opt/maven" >> $GITHUB_ENV
           echo "/opt/maven/bin" >> $GITHUB_PATH

--- a/.github/workflows/build-csharp.yml
+++ b/.github/workflows/build-csharp.yml
@@ -141,8 +141,13 @@ jobs:
       - name: Install Maven
         shell: bash
         run: |
-          curl -sSL https://archive.apache.org/dist/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz | tar xz
-          mv apache-maven-3.9.12 /opt/maven
+          MAVEN_VERSION=3.9.15
+          curl -sSL --retry 3 --retry-delay 5 https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+            -o maven.tar.gz || \
+          curl -sSL --retry 3 --retry-delay 5 https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+            -o maven.tar.gz
+          tar xzf maven.tar.gz
+          mv apache-maven-${MAVEN_VERSION} /opt/maven
           echo "MAVEN_HOME=/opt/maven" >> $GITHUB_ENV
           echo "/opt/maven/bin" >> $GITHUB_PATH
     

--- a/multilang-schema-registry/demos/csharp/Consumer/Consumer.csproj
+++ b/multilang-schema-registry/demos/csharp/Consumer/Consumer.csproj
@@ -6,21 +6,25 @@
     <RootNamespace>ProtobufGSRKafkaDemo.Consumer</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AWSGsrSerDeVersion>1.0.0</AWSGsrSerDeVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="KafkaFlow" Version="3.0.10" />
     <PackageReference Include="KafkaFlow.Extensions.Hosting" Version="3.0.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <!--
+      AWS.Glue.SchemaRegistry NuGet package ships platform-specific native libraries.
+      The version suffix must match your target runtime:
+        - linux-x64       : glibc-based Linux (Debian, Ubuntu, Amazon Linux, etc.)
+        - linux-musl-x64  : musl-based Linux (Alpine)
+        - linux-arm64     : glibc-based Linux on ARM64
+      Update the version below if deploying to a different platform.
+    -->
+    <PackageReference Include="AWS.Glue.SchemaRegistry" Version="1.0.1-linux-musl-x64" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../Shared/Shared.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="AWSGsrSerDe" Version="$(AWSGsrSerDeVersion)" />
   </ItemGroup>
 
 </Project>

--- a/multilang-schema-registry/demos/csharp/Consumer/Consumer.csproj
+++ b/multilang-schema-registry/demos/csharp/Consumer/Consumer.csproj
@@ -20,7 +20,7 @@
         - linux-arm64     : glibc-based Linux on ARM64
       Update the version below if deploying to a different platform.
     -->
-    <PackageReference Include="AWS.Glue.SchemaRegistry" Version="1.0.1-linux-musl-x64" />
+    <PackageReference Include="AWS.Glue.SchemaRegistry" Version="1.0.1-linux-x64" />
   </ItemGroup>
 
   <ItemGroup>

--- a/multilang-schema-registry/demos/csharp/Consumer/run-consumer.sh
+++ b/multilang-schema-registry/demos/csharp/Consumer/run-consumer.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 echo "Starting Protobuf GSR Kafka Consumer..."
-export LD_LIBRARY_PATH=../../csharp/AWSGsrSerDe/Libs:$LD_LIBRARY_PATH
 dotnet run --project Consumer.csproj

--- a/multilang-schema-registry/demos/csharp/Producer/Producer.csproj
+++ b/multilang-schema-registry/demos/csharp/Producer/Producer.csproj
@@ -6,21 +6,25 @@
     <RootNamespace>ProtobufGSRKafkaDemo.Producer</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AWSGsrSerDeVersion>1.0.0</AWSGsrSerDeVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="KafkaFlow" Version="3.0.10" />
     <PackageReference Include="KafkaFlow.Extensions.Hosting" Version="3.0.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <!--
+      AWS.Glue.SchemaRegistry NuGet package ships platform-specific native libraries.
+      The version suffix must match your target runtime:
+        - linux-x64       : glibc-based Linux (Debian, Ubuntu, Amazon Linux, etc.)
+        - linux-musl-x64  : musl-based Linux (Alpine)
+        - linux-arm64     : glibc-based Linux on ARM64
+      Update the version below if deploying to a different platform.
+    -->
+    <PackageReference Include="AWS.Glue.SchemaRegistry" Version="1.0.1-linux-musl-x64" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../Shared/Shared.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="AWSGsrSerDe" Version="$(AWSGsrSerDeVersion)" />
   </ItemGroup>
 
 </Project>

--- a/multilang-schema-registry/demos/csharp/Producer/Producer.csproj
+++ b/multilang-schema-registry/demos/csharp/Producer/Producer.csproj
@@ -20,7 +20,7 @@
         - linux-arm64     : glibc-based Linux on ARM64
       Update the version below if deploying to a different platform.
     -->
-    <PackageReference Include="AWS.Glue.SchemaRegistry" Version="1.0.1-linux-musl-x64" />
+    <PackageReference Include="AWS.Glue.SchemaRegistry" Version="1.0.1-linux-x64" />
   </ItemGroup>
 
   <ItemGroup>

--- a/multilang-schema-registry/demos/csharp/Producer/run-producer.sh
+++ b/multilang-schema-registry/demos/csharp/Producer/run-producer.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 echo "Starting Protobuf GSR Kafka Producer..."
-export LD_LIBRARY_PATH=../../csharp/AWSGsrSerDe/Libs:$LD_LIBRARY_PATH
 dotnet run --project Producer.csproj

--- a/multilang-schema-registry/demos/csharp/Shared/Shared.csproj
+++ b/multilang-schema-registry/demos/csharp/Shared/Shared.csproj
@@ -19,7 +19,7 @@
         - linux-arm64     : glibc-based Linux on ARM64
       Update the version below if deploying to a different platform.
     -->
-    <PackageReference Include="AWS.Glue.SchemaRegistry" Version="1.0.1-linux-musl-x64" />
+    <PackageReference Include="AWS.Glue.SchemaRegistry" Version="1.0.1-linux-x64" />
   </ItemGroup>
 
   <ItemGroup>

--- a/multilang-schema-registry/demos/csharp/Shared/Shared.csproj
+++ b/multilang-schema-registry/demos/csharp/Shared/Shared.csproj
@@ -5,17 +5,21 @@
     <RootNamespace>ProtobufGSRKafkaDemo</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AWSGsrSerDeVersion>1.0.0</AWSGsrSerDeVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.32.1" />
     <PackageReference Include="Grpc.Tools" Version="2.59.0" PrivateAssets="All" />
     <PackageReference Include="KafkaFlow" Version="3.0.10" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="AWSGsrSerDe" Version="$(AWSGsrSerDeVersion)" />
+    <!--
+      AWS.Glue.SchemaRegistry NuGet package ships platform-specific native libraries.
+      The version suffix must match your target runtime:
+        - linux-x64       : glibc-based Linux (Debian, Ubuntu, Amazon Linux, etc.)
+        - linux-musl-x64  : musl-based Linux (Alpine)
+        - linux-arm64     : glibc-based Linux on ARM64
+      Update the version below if deploying to a different platform.
+    -->
+    <PackageReference Include="AWS.Glue.SchemaRegistry" Version="1.0.1-linux-musl-x64" />
   </ItemGroup>
 
   <ItemGroup>

--- a/multilang-schema-registry/demos/csharp/docker-compose.yml
+++ b/multilang-schema-registry/demos/csharp/docker-compose.yml
@@ -73,6 +73,5 @@ services:
     volumes:
       - ~/.aws:/root/.aws:ro
       - .:/workplace/demos/csharp
-      - ../../csharp:/workplace/csharp
     working_dir: /workplace/demos/csharp
     command: ["./run-demo.sh"]

--- a/multilang-schema-registry/demos/csharp/nuget.config
+++ b/multilang-schema-registry/demos/csharp/nuget.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="local-packages" value="../../csharp/AWSGsrSerDe/AWSGsrSerDe/bin/Release" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
*Issue #, if available:* Right now the demo project uses local build, which while useful, is not reflective of a real client application.

*Description of changes:* This change modifies the demo project csproj files to use actual libraries published to Nuget.

*Evidence of demo project runs*:
1. Glibc
<img width="940" height="232" alt="image" src="https://github.com/user-attachments/assets/5c6d845e-b5bd-423c-b400-68d1515c9979" />


2. Musl
<img width="940" height="232" alt="image" src="https://github.com/user-attachments/assets/8f337750-8a28-41f7-8980-c5612de7e16f" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
