### PR TITLE
fix(integration-tests): pin localstack to 4.12 to make Kinesis integration tests functional again

### DIFF
--- a/.github/workflows/build-csharp.yml
+++ b/.github/workflows/build-csharp.yml
@@ -142,9 +142,9 @@ jobs:
         shell: bash
         run: |
           MAVEN_VERSION=3.9.15
-          curl -sSL --retry 3 --retry-delay 5 https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+          curl -fsSL --retry 3 --retry-delay 5 https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
             -o maven.tar.gz || \
-          curl -sSL --retry 3 --retry-delay 5 https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+          curl -fsSL --retry 3 --retry-delay 5 https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
             -o maven.tar.gz
           tar xzf maven.tar.gz
           mv apache-maven-${MAVEN_VERSION} /opt/maven

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -24,7 +24,7 @@ services:
 
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
-    image: 'public.ecr.aws/localstack/localstack:latest'
+    image: 'public.ecr.aws/localstack/localstack:4.12'
     ports:
       - "127.0.0.1:4566:4566"
     environment:


### PR DESCRIPTION
The integration test suite regressed because docker-compose.yml pulled public.ecr.aws/localstack/localstack:latest, and the recent published revision under :latest needs a pro license to work.

So, we've decided to pin to the december release [4.12](https://blog.localstack.cloud/localstack-for-aws-release-v-4-12-0/), the last image revision known to work without such restrictions.

## Before
Failed with
```
Reason: No credentials were found in the environment. Please make sure to either set the LOCALSTACK_AUTH_TOKEN variable to a valid auth token. If you are using the CLI, you can also run `localstack auth set-token`.

```

## After
Verified:
- Unit tests: BUILD SUCCESS, 9 modules, 1m 20s
- Integration: BUILD SUCCESS, 73 tests, 0 failures, 0 errors
  - Kafka: 45 tests, 12m 21s
  - Kinesis (KPL/KCL vs LocalStack 4.12): 28 tests, 8m 23s

```
[INFO] Tests run: 45, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 741.817 s - in com.amazonaws.services.schemaregistry.integrationtests.kafka.GlueSchemaRegistryKafkaIntegrationTest
[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 502.983 s - in com.amazonaws.services.schemaregistry.integrationtests.kinesis.GlueSchemaRegistryKinesisIntegrationTest
[INFO] Tests run: 73, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```


### We will take an action item to migrate to a more permanent solution because, pinning is not a long term solution as mentioned in: https://blog.localstack.cloud/localstack-single-image-next-steps/

As per the blog, pinning:
1. Increases parity drift over time
2. You’ll accumulate security and compliance debt
3. CI is typically where pinning becomes fragile first
4. We’ll upgrade later” becomes a larger migration event