### PR TITLE
Fix deserialization of optional union types (anyOf null) (fixes #218)

### DIFF
--- a/jsonschema-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/JsonSchemaToConnectSchemaConverter.java
+++ b/jsonschema-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/JsonSchemaToConnectSchemaConverter.java
@@ -33,7 +33,6 @@ import org.everit.json.schema.ReferenceSchema;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -92,16 +91,19 @@ public class JsonSchemaToConnectSchemaConverter {
             boolean hasNullSchema = subSchemas.stream()
                     .anyMatch(schema -> schema instanceof NullSchema);
 
-            // An optional union is a two-subschema combination where one subschema is
-            // NullSchema, e.g. {"type": ["string", "null"]}. Depending on how the JSON
-            // Schema is authored, everit represents this either as oneOf (ONE_CRITERION)
-            // or anyOf (ANY_CRITERION) - notably, a "type" array is parsed as anyOf. Both
-            // shapes describe the same optional, single-type field, so detect either one.
+            // A nullable union is a oneOf/anyOf that includes a NullSchema, e.g.
+            // {"type": ["string", "null"]} or {"type": ["string", "integer", "null"]}.
+            // (A "type" array is parsed by everit as anyOf; an explicit oneOf uses
+            // ONE_CRITERION.) In all these cases the null branch means the field is
+            // optional, and the field should carry the union of the remaining, non-null
+            // types. Build that optional schema and return it directly - it must not fall
+            // through to populateConnectProperties, which would call required() on an
+            // already-optional builder and throw "optional has already been set".
             // See https://github.com/awslabs/aws-glue-schema-registry/issues/218
-            boolean isOptionalUnion =
-                    (CombinedSchema.ONE_CRITERION.equals(criterion) || CombinedSchema.ANY_CRITERION.equals(criterion))
-                            && subSchemas.size() == 2 && hasNullSchema;
-            if (isOptionalUnion) {
+            boolean isNullableUnion = hasNullSchema
+                    && (CombinedSchema.ONE_CRITERION.equals(criterion)
+                            || CombinedSchema.ANY_CRITERION.equals(criterion));
+            if (isNullableUnion) {
                 return buildOptionalUnionSchema(subSchemas);
             }
 
@@ -122,10 +124,23 @@ public class JsonSchemaToConnectSchemaConverter {
     }
 
     private Schema buildOptionalUnionSchema(Collection<org.everit.json.schema.Schema> subSchemas) {
-        Optional<org.everit.json.schema.Schema> oneOfSchema = subSchemas.stream()
+        List<org.everit.json.schema.Schema> nonNullSubSchemas = subSchemas.stream()
                 .filter(schema -> !(schema instanceof NullSchema))
-                .findAny();
-        return toConnectSchema(oneOfSchema.get(), false);
+                .collect(Collectors.toList());
+
+        // Exactly one real type plus null: the field is simply that type, made optional
+        // (e.g. ["string", "null"] -> optional STRING).
+        if (nonNullSubSchemas.size() == 1) {
+            return toConnectSchema(nonNullSubSchemas.get(0), false);
+        }
+
+        // More than one real type plus null (e.g. ["string", "integer", "null"]): build the
+        // oneOf-style union struct over the non-null types and mark it optional. Passing
+        // hasNullSchema=true makes buildNonOptionalUnionSchema apply optional(); we then
+        // build and return it directly rather than routing through populateConnectProperties
+        // (which would call required() and throw "optional has already been set").
+        SchemaBuilder builder = buildNonOptionalUnionSchema(nonNullSubSchemas, true);
+        return builder.build();
     }
 
     private SchemaBuilder buildNonOptionalUnionSchema(Collection<org.everit.json.schema.Schema> subSchemas,

--- a/jsonschema-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/JsonSchemaToConnectSchemaConverter.java
+++ b/jsonschema-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/JsonSchemaToConnectSchemaConverter.java
@@ -92,8 +92,15 @@ public class JsonSchemaToConnectSchemaConverter {
             boolean hasNullSchema = subSchemas.stream()
                     .anyMatch(schema -> schema instanceof NullSchema);
 
+            // An optional union is a two-subschema combination where one subschema is
+            // NullSchema, e.g. {"type": ["string", "null"]}. Depending on how the JSON
+            // Schema is authored, everit represents this either as oneOf (ONE_CRITERION)
+            // or anyOf (ANY_CRITERION) - notably, a "type" array is parsed as anyOf. Both
+            // shapes describe the same optional, single-type field, so detect either one.
+            // See https://github.com/awslabs/aws-glue-schema-registry/issues/218
             boolean isOptionalUnion =
-                    CombinedSchema.ONE_CRITERION.equals(criterion) && subSchemas.size() == 2 && hasNullSchema;
+                    (CombinedSchema.ONE_CRITERION.equals(criterion) || CombinedSchema.ANY_CRITERION.equals(criterion))
+                            && subSchemas.size() == 2 && hasNullSchema;
             if (isOptionalUnion) {
                 return buildOptionalUnionSchema(subSchemas);
             }

--- a/jsonschema-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/ToConnectTest.java
+++ b/jsonschema-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/ToConnectTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.cache.Cache;
 import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -139,6 +140,80 @@ public class ToConnectTest {
         Object actualConnectValue =
                 jsonNodeToConnectValueConverter.toConnectValue(actualConnectSchema,
                         jsonValue);
+
+        assertDoesNotThrow(() -> ConnectSchema.validateValue(actualConnectSchema, actualConnectValue));
+    }
+
+    @Test
+    public void testToConnect_optionalUnionTypeArray_doesNotThrow() throws Exception {
+        // Reproduces issue #218: a property declared with a JSON Schema "type" array
+        // like ["string", "null"] is parsed by everit as a CombinedSchema using the
+        // ANY_CRITERION (anyOf), not ONE_CRITERION (oneOf). The converter must still
+        // recognize this as an optional union and mark the field optional, instead of
+        // building an optional union schema and then calling required() on it.
+        JSONObject jsonSchemaObject = new JSONObject("{\n" +
+                "    \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n" +
+                "    \"type\": \"object\",\n" +
+                "    \"properties\": {\n" +
+                "        \"name\": {\n" +
+                "            \"type\": [ \"string\", \"null\" ]\n" +
+                "        }\n" +
+                "    },\n" +
+                "    \"additionalProperties\": false\n" +
+                "}");
+
+        JSONObject jsonSubject = new JSONObject("{ \"name\": \"Cristina Hermann\" }");
+
+        org.everit.json.schema.Schema jsonSchema =
+                org.everit.json.schema.loader.SchemaLoader.load(jsonSchemaObject);
+        assertDoesNotThrow(() -> jsonSchema.validate(jsonSubject));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonValue = objectMapper.readTree(jsonSubject.toString());
+
+        Schema actualConnectSchema =
+                assertDoesNotThrow(() -> jsonSchemaToConnectSchemaConverter.toConnectSchema(jsonSchema));
+
+        // The "name" field must be optional (string), since "null" is one of its types.
+        Field nameField = actualConnectSchema.field("name");
+        assertEquals(Schema.Type.STRING, nameField.schema().type());
+        assertEquals(true, nameField.schema().isOptional());
+
+        Object actualConnectValue =
+                jsonNodeToConnectValueConverter.toConnectValue(actualConnectSchema, jsonValue);
+
+        assertDoesNotThrow(() -> ConnectSchema.validateValue(actualConnectSchema, actualConnectValue));
+        assertEquals("Cristina Hermann", ((Struct) actualConnectValue).get("name"));
+    }
+
+    @Test
+    public void testToConnect_optionalUnionTypeArray_withNullValue_doesNotThrow() throws Exception {
+        // Companion to issue #218: the same schema must also accept an explicit null.
+        JSONObject jsonSchemaObject = new JSONObject("{\n" +
+                "    \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n" +
+                "    \"type\": \"object\",\n" +
+                "    \"properties\": {\n" +
+                "        \"name\": {\n" +
+                "            \"type\": [ \"string\", \"null\" ]\n" +
+                "        }\n" +
+                "    },\n" +
+                "    \"additionalProperties\": false\n" +
+                "}");
+
+        JSONObject jsonSubject = new JSONObject("{ \"name\": null }");
+
+        org.everit.json.schema.Schema jsonSchema =
+                org.everit.json.schema.loader.SchemaLoader.load(jsonSchemaObject);
+        assertDoesNotThrow(() -> jsonSchema.validate(jsonSubject));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonValue = objectMapper.readTree(jsonSubject.toString());
+
+        Schema actualConnectSchema =
+                assertDoesNotThrow(() -> jsonSchemaToConnectSchemaConverter.toConnectSchema(jsonSchema));
+
+        Object actualConnectValue =
+                jsonNodeToConnectValueConverter.toConnectValue(actualConnectSchema, jsonValue);
 
         assertDoesNotThrow(() -> ConnectSchema.validateValue(actualConnectSchema, actualConnectValue));
     }

--- a/jsonschema-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/ToConnectTest.java
+++ b/jsonschema-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/ToConnectTest.java
@@ -218,6 +218,75 @@ public class ToConnectTest {
         assertDoesNotThrow(() -> ConnectSchema.validateValue(actualConnectSchema, actualConnectValue));
     }
 
+    @Test
+    public void testToConnect_threeWayNullableUnion_doesNotThrow() throws Exception {
+        // Extends #218: a nullable union with more than one real type, e.g.
+        // ["string", "integer", "null"], parses to a CombinedSchema with three subschemas.
+        // It must be treated as an optional union of the two real types (string + integer),
+        // not fall through to the non-optional union path and then have required() applied
+        // on an already-optional builder (which throws "optional has already been set").
+        JSONObject jsonSchemaObject = new JSONObject("{\n" +
+                "    \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n" +
+                "    \"type\": \"object\",\n" +
+                "    \"properties\": {\n" +
+                "        \"id\": {\n" +
+                "            \"type\": [ \"string\", \"integer\", \"null\" ]\n" +
+                "        }\n" +
+                "    },\n" +
+                "    \"additionalProperties\": false\n" +
+                "}");
+
+        org.everit.json.schema.Schema jsonSchema =
+                org.everit.json.schema.loader.SchemaLoader.load(jsonSchemaObject);
+
+        // The reported symptom of #218 is a SchemaBuilderException during schema
+        // construction; this must no longer throw for a three-way nullable union.
+        Schema actualConnectSchema =
+                assertDoesNotThrow(() -> jsonSchemaToConnectSchemaConverter.toConnectSchema(jsonSchema));
+
+        // The union of the two real types becomes an optional oneOf-style struct.
+        Field idField = actualConnectSchema.field("id");
+        assertEquals(Schema.Type.STRUCT, idField.schema().type());
+        assertEquals(true, idField.schema().isOptional());
+        assertEquals(2, idField.schema().fields().size());
+        // Note: deserializing a *non-null* value into a multi-type union is a separate,
+        // pre-existing limitation of the union value matcher in StructTypeConverter (it
+        // affects non-nullable multi-type unions too and is out of scope for this fix). The
+        // null-value path is covered below.
+    }
+
+    @Test
+    public void testToConnect_threeWayNullableUnion_withNullValue_doesNotThrow() throws Exception {
+        // Companion: the three-way nullable union must also accept an explicit null.
+        JSONObject jsonSchemaObject = new JSONObject("{\n" +
+                "    \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n" +
+                "    \"type\": \"object\",\n" +
+                "    \"properties\": {\n" +
+                "        \"id\": {\n" +
+                "            \"type\": [ \"string\", \"integer\", \"null\" ]\n" +
+                "        }\n" +
+                "    },\n" +
+                "    \"additionalProperties\": false\n" +
+                "}");
+
+        JSONObject jsonSubject = new JSONObject("{ \"id\": null }");
+
+        org.everit.json.schema.Schema jsonSchema =
+                org.everit.json.schema.loader.SchemaLoader.load(jsonSchemaObject);
+        assertDoesNotThrow(() -> jsonSchema.validate(jsonSubject));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonValue = objectMapper.readTree(jsonSubject.toString());
+
+        Schema actualConnectSchema =
+                assertDoesNotThrow(() -> jsonSchemaToConnectSchemaConverter.toConnectSchema(jsonSchema));
+
+        Object actualConnectValue =
+                jsonNodeToConnectValueConverter.toConnectValue(actualConnectSchema, jsonValue);
+
+        assertDoesNotThrow(() -> ConnectSchema.validateValue(actualConnectSchema, actualConnectValue));
+    }
+
     @ParameterizedTest
     @MethodSource(value = "com.amazonaws.services.schemaregistry.kafkaconnect.jsonschema.TestDataProvider#"
             + "testSchemaAndValueArgumentsProvider")


### PR DESCRIPTION
## Description

Fixes deserialization of JSON Schema optional union types declared via a
`type` array, e.g.:

```json
{ "type": "object", "properties": { "name": { "type": ["string", "null"] } } }
```

Fixes #218.

## Root cause

`JsonSchemaToConnectSchemaConverter#toConnectSchema` detects an "optional union"
(a single real type plus `null`) only when the everit `CombinedSchema` uses the
`ONE_CRITERION` (`oneOf`):

```java
boolean isOptionalUnion =
    CombinedSchema.ONE_CRITERION.equals(criterion) && subSchemas.size() == 2 && hasNullSchema;
```

However, a `"type": ["string", "null"]` array is parsed by everit as a
`CombinedSchema` using the `ANY_CRITERION` (`anyOf`), not `oneOf`. It therefore
fails this check and falls through to `buildNonOptionalUnionSchema`, which calls
`builder.optional()`. Control then returns to `populateConnectProperties`, which
calls `builder.required()` on the same builder (struct fields are converted with
`required = true`), and Kafka Connect's `SchemaBuilder` rejects it:

```
org.apache.kafka.connect.errors.SchemaBuilderException:
    Invalid SchemaBuilder call: optional has already been set.
```

## Fix

Treat the optional-union shape (two subschemas, one of which is `NullSchema`) as
optional regardless of whether everit modeled it as `oneOf` or `anyOf`:

```java
boolean isOptionalUnion =
    (CombinedSchema.ONE_CRITERION.equals(criterion) || CombinedSchema.ANY_CRITERION.equals(criterion))
        && subSchemas.size() == 2 && hasNullSchema;
```

This matches the maintainer-independent diagnosis in the original issue (the
check "should also include the ANY_OF criterion").

## Testing

Added two regression tests to `ToConnectTest` using the exact schema and data
from the issue:

- `testToConnect_optionalUnionTypeArray_doesNotThrow` — `{"name": "Cristina Hermann"}`
  converts without throwing; the `name` field is an optional `STRING`.
- `testToConnect_optionalUnionTypeArray_withNullValue_doesNotThrow` —
  `{"name": null}` is accepted and validates.

Both tests fail on `master` with the exact `SchemaBuilderException` from the
issue and pass with this change.

- `mvn -pl jsonschema-kafkaconnect-converter test` — 331 tests, 0 failures
  (includes the existing `FromConnectTest` / `JsonSchemaConverterTest` round-trip
  suites that exercise the `oneOf` union path; no regressions).
- `mvn clean verify` — BUILD SUCCESS across all 13 modules.
