### PR TITLE
Support JSON Schema const types in Kafka Connect converter

### DIFF
--- a/jsonschema-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/JsonSchemaToConnectSchemaConverter.java
+++ b/jsonschema-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/JsonSchemaToConnectSchemaConverter.java
@@ -27,13 +27,16 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.errors.DataException;
 import org.everit.json.schema.CombinedSchema;
+import org.everit.json.schema.ConstSchema;
 import org.everit.json.schema.NullSchema;
 import org.everit.json.schema.ReferenceSchema;
 
+import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 /**
@@ -84,6 +87,13 @@ public class JsonSchemaToConnectSchemaConverter {
 
         if (typeConverter != null) {
             builder = typeConverter.toConnectSchema(jsonSchema, jsonSchemaDataConfig);
+        } else if (jsonSchema instanceof ConstSchema) {
+            // JSON Schema "const" (draft-06+) restricts a value to a single permitted
+            // value, which may be any JSON value - scalar, object, or array. everit exposes
+            // that value via getPermittedValue(). We infer a Connect schema from the value's
+            // shape so both schema translation and value deserialization work through the
+            // normal Connect type machinery. See issue: const types unsupported.
+            builder = buildConstSchema((ConstSchema) jsonSchema);
         } else if (jsonSchema instanceof CombinedSchema) {
             CombinedSchema combinedSchema = (CombinedSchema) jsonSchema;
             Collection<org.everit.json.schema.Schema> subSchemas = combinedSchema.getSubschemas();
@@ -119,6 +129,85 @@ public class JsonSchemaToConnectSchemaConverter {
                 .filter(schema -> !(schema instanceof NullSchema))
                 .findAny();
         return toConnectSchema(oneOfSchema.get(), false);
+    }
+
+    /**
+     * Builds a Connect schema for a JSON Schema {@code const} by inferring the schema from
+     * the Java type of the single permitted value. Objects become STRUCTs, arrays become
+     * ARRAYs (with a homogeneous element type), and scalars map to their Connect types.
+     *
+     * <p>Note: this preserves the <em>type</em> of the const value so that data flows
+     * through correctly, but it does not enforce the const <em>constraint</em> (that the
+     * value must equal the permitted value); Connect's schema model has no equivalent, and
+     * the constraint is not round-tripped, consistent with how other JSON Schema validation
+     * keywords (pattern, minimum, format, ...) are handled.
+     */
+    private SchemaBuilder buildConstSchema(ConstSchema constSchema) {
+        return inferSchemaBuilderFromValue(constSchema.getPermittedValue());
+    }
+
+    private SchemaBuilder inferSchemaBuilderFromValue(Object value) {
+        if (value == null) {
+            throw new DataException(
+                    "Cannot infer a Connect schema for a JSON Schema 'const' with a null value");
+        } else if (value instanceof Boolean) {
+            return SchemaBuilder.bool();
+        } else if (value instanceof Integer || value instanceof Long || value instanceof Short
+                || value instanceof Byte || value instanceof BigInteger) {
+            return SchemaBuilder.int64();
+        } else if (value instanceof Number) {
+            // Float, Double, BigDecimal and any other non-integral number.
+            return SchemaBuilder.float64();
+        } else if (value instanceof CharSequence) {
+            return SchemaBuilder.string();
+        } else if (value instanceof Map) {
+            return inferStructBuilderFromValue((Map<?, ?>) value);
+        } else if (value instanceof Collection) {
+            return inferArrayBuilderFromValue((Collection<?>) value);
+        }
+        throw new DataException("Unsupported JSON Schema 'const' value type: "
+                + value.getClass().getName());
+    }
+
+    private SchemaBuilder inferStructBuilderFromValue(Map<?, ?> map) {
+        SchemaBuilder builder = SchemaBuilder.struct();
+        // Sort by key so the generated STRUCT has a deterministic field order regardless of
+        // the Map implementation everit returns.
+        Map<String, Object> sortedFields = new TreeMap<>();
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            sortedFields.put(String.valueOf(entry.getKey()), entry.getValue());
+        }
+        for (Map.Entry<String, Object> entry : sortedFields.entrySet()) {
+            if (entry.getValue() == null) {
+                throw new DataException("Cannot infer a Connect schema for the 'const' object field '"
+                        + entry.getKey() + "' because its value is null");
+            }
+            builder.field(entry.getKey(), inferSchemaBuilderFromValue(entry.getValue()).build());
+        }
+        return builder;
+    }
+
+    private SchemaBuilder inferArrayBuilderFromValue(Collection<?> collection) {
+        if (collection.isEmpty()) {
+            throw new DataException(
+                    "Cannot infer a Connect element schema for an empty 'const' array");
+        }
+        Schema elementSchema = null;
+        for (Object element : collection) {
+            if (element == null) {
+                throw new DataException(
+                        "Cannot infer a Connect schema for a null element in a 'const' array");
+            }
+            Schema candidate = inferSchemaBuilderFromValue(element).build();
+            if (elementSchema == null) {
+                elementSchema = candidate;
+            } else if (!elementSchema.equals(candidate)) {
+                throw new DataException("Cannot convert a heterogeneous 'const' array to a Connect ARRAY; "
+                        + "all elements must have the same type, but found " + elementSchema.type()
+                        + " and " + candidate.type());
+            }
+        }
+        return SchemaBuilder.array(elementSchema);
     }
 
     private SchemaBuilder buildNonOptionalUnionSchema(Collection<org.everit.json.schema.Schema> subSchemas,

--- a/jsonschema-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/typeconverters/TypeConverterFactory.java
+++ b/jsonschema-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/typeconverters/TypeConverterFactory.java
@@ -23,6 +23,7 @@ import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.DataException;
 import org.everit.json.schema.ArraySchema;
 import org.everit.json.schema.BooleanSchema;
+import org.everit.json.schema.ConstSchema;
 import org.everit.json.schema.EnumSchema;
 import org.everit.json.schema.NumberSchema;
 import org.everit.json.schema.ObjectSchema;
@@ -60,6 +61,12 @@ public class TypeConverterFactory {
             typeConverter = "bytes".equals(connectType) ? get(Schema.Type.BYTES) : get(Schema.Type.STRING);
         } else if (jsonSchema instanceof EnumSchema) {
             typeConverter = get(Schema.Type.STRING);
+        } else if (jsonSchema instanceof ConstSchema) {
+            // JSON Schema "const" restricts a value to a single permitted value. everit
+            // models this as a ConstSchema (rather than a typed schema), so map it to a
+            // Connect type based on the Java type of the permitted value. This routes both
+            // schema and value conversion through the existing type converters.
+            typeConverter = getForConstValue(((ConstSchema) jsonSchema).getPermittedValue(), connectType);
         } else if (jsonSchema instanceof ArraySchema) {
             if ("map".equals(connectType)) {
                 typeConverter = get(Schema.Type.MAP);
@@ -75,6 +82,41 @@ public class TypeConverterFactory {
         }
 
         return typeConverter;
+    }
+
+    /**
+     * Maps the permitted value of a JSON Schema {@code const} to the appropriate Connect
+     * TypeConverter based on the Java type of the value. A connect type hint, when present,
+     * takes precedence so that values carrying explicit Connect type metadata are honored.
+     *
+     * @param permittedValue the single permitted value of the const schema
+     * @param connectType    optional connect type hint from unprocessed properties
+     * @return the matching TypeConverter
+     */
+    private TypeConverter getForConstValue(Object permittedValue,
+                                           String connectType) {
+        if (connectType != null) {
+            if ("bytes".equals(connectType)) {
+                return get(Schema.Type.BYTES);
+            }
+            if ("map".equals(connectType)) {
+                return get(Schema.Type.MAP);
+            }
+            return get(Schema.Type.valueOf(connectType.toUpperCase()));
+        }
+
+        if (permittedValue instanceof Boolean) {
+            return get(Schema.Type.BOOLEAN);
+        } else if (permittedValue instanceof Integer || permittedValue instanceof Long
+                || permittedValue instanceof Short || permittedValue instanceof Byte) {
+            return get(Schema.Type.INT64);
+        } else if (permittedValue instanceof Float || permittedValue instanceof Double
+                || permittedValue instanceof Number) {
+            return get(Schema.Type.FLOAT64);
+        }
+
+        // Strings and any other JSON scalar (e.g. values surfaced as text) map to STRING.
+        return get(Schema.Type.STRING);
     }
 
     /**

--- a/jsonschema-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/typeconverters/TypeConverterFactory.java
+++ b/jsonschema-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/typeconverters/TypeConverterFactory.java
@@ -23,7 +23,6 @@ import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.DataException;
 import org.everit.json.schema.ArraySchema;
 import org.everit.json.schema.BooleanSchema;
-import org.everit.json.schema.ConstSchema;
 import org.everit.json.schema.EnumSchema;
 import org.everit.json.schema.NumberSchema;
 import org.everit.json.schema.ObjectSchema;
@@ -61,12 +60,6 @@ public class TypeConverterFactory {
             typeConverter = "bytes".equals(connectType) ? get(Schema.Type.BYTES) : get(Schema.Type.STRING);
         } else if (jsonSchema instanceof EnumSchema) {
             typeConverter = get(Schema.Type.STRING);
-        } else if (jsonSchema instanceof ConstSchema) {
-            // JSON Schema "const" restricts a value to a single permitted value. everit
-            // models this as a ConstSchema (rather than a typed schema), so map it to a
-            // Connect type based on the Java type of the permitted value. This routes both
-            // schema and value conversion through the existing type converters.
-            typeConverter = getForConstValue(((ConstSchema) jsonSchema).getPermittedValue(), connectType);
         } else if (jsonSchema instanceof ArraySchema) {
             if ("map".equals(connectType)) {
                 typeConverter = get(Schema.Type.MAP);
@@ -82,41 +75,6 @@ public class TypeConverterFactory {
         }
 
         return typeConverter;
-    }
-
-    /**
-     * Maps the permitted value of a JSON Schema {@code const} to the appropriate Connect
-     * TypeConverter based on the Java type of the value. A connect type hint, when present,
-     * takes precedence so that values carrying explicit Connect type metadata are honored.
-     *
-     * @param permittedValue the single permitted value of the const schema
-     * @param connectType    optional connect type hint from unprocessed properties
-     * @return the matching TypeConverter
-     */
-    private TypeConverter getForConstValue(Object permittedValue,
-                                           String connectType) {
-        if (connectType != null) {
-            if ("bytes".equals(connectType)) {
-                return get(Schema.Type.BYTES);
-            }
-            if ("map".equals(connectType)) {
-                return get(Schema.Type.MAP);
-            }
-            return get(Schema.Type.valueOf(connectType.toUpperCase()));
-        }
-
-        if (permittedValue instanceof Boolean) {
-            return get(Schema.Type.BOOLEAN);
-        } else if (permittedValue instanceof Integer || permittedValue instanceof Long
-                || permittedValue instanceof Short || permittedValue instanceof Byte) {
-            return get(Schema.Type.INT64);
-        } else if (permittedValue instanceof Float || permittedValue instanceof Double
-                || permittedValue instanceof Number) {
-            return get(Schema.Type.FLOAT64);
-        }
-
-        // Strings and any other JSON scalar (e.g. values surfaced as text) map to STRING.
-        return get(Schema.Type.STRING);
     }
 
     /**

--- a/jsonschema-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/ToConnectTest.java
+++ b/jsonschema-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/ToConnectTest.java
@@ -143,6 +143,98 @@ public class ToConnectTest {
         assertDoesNotThrow(() -> ConnectSchema.validateValue(actualConnectSchema, actualConnectValue));
     }
 
+    @Test
+    public void testToConnect_constStringType_doesNotThrow() throws Exception {
+        // Customer feedback: JSON Schema "const" types are not supported by the Kafka
+        // Connect translation. everit parses "const" as a ConstSchema, which the
+        // TypeConverterFactory did not handle, producing:
+        //   DataException: Unsupported schema type org.everit.json.schema.ConstSchema
+        JSONObject jsonSchemaObject = new JSONObject("{\n" +
+                "    \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n" +
+                "    \"type\": \"object\",\n" +
+                "    \"properties\": {\n" +
+                "        \"country\": { \"const\": \"United States of America\" }\n" +
+                "    },\n" +
+                "    \"additionalProperties\": false\n" +
+                "}");
+
+        JSONObject jsonSubject = new JSONObject("{ \"country\": \"United States of America\" }");
+
+        org.everit.json.schema.Schema jsonSchema =
+                org.everit.json.schema.loader.SchemaLoader.load(jsonSchemaObject);
+        assertDoesNotThrow(() -> jsonSchema.validate(jsonSubject));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonValue = objectMapper.readTree(jsonSubject.toString());
+
+        Schema actualConnectSchema =
+                assertDoesNotThrow(() -> jsonSchemaToConnectSchemaConverter.toConnectSchema(jsonSchema));
+        assertEquals(Schema.Type.STRING, actualConnectSchema.field("country").schema().type());
+
+        Object actualConnectValue =
+                jsonNodeToConnectValueConverter.toConnectValue(actualConnectSchema, jsonValue);
+        assertDoesNotThrow(() -> ConnectSchema.validateValue(actualConnectSchema, actualConnectValue));
+        assertEquals("United States of America", ((Struct) actualConnectValue).get("country"));
+    }
+
+    @Test
+    public void testToConnect_constNumberType_doesNotThrow() throws Exception {
+        JSONObject jsonSchemaObject = new JSONObject("{\n" +
+                "    \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n" +
+                "    \"type\": \"object\",\n" +
+                "    \"properties\": {\n" +
+                "        \"version\": { \"const\": 1 }\n" +
+                "    },\n" +
+                "    \"additionalProperties\": false\n" +
+                "}");
+
+        JSONObject jsonSubject = new JSONObject("{ \"version\": 1 }");
+
+        org.everit.json.schema.Schema jsonSchema =
+                org.everit.json.schema.loader.SchemaLoader.load(jsonSchemaObject);
+        assertDoesNotThrow(() -> jsonSchema.validate(jsonSubject));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonValue = objectMapper.readTree(jsonSubject.toString());
+
+        Schema actualConnectSchema =
+                assertDoesNotThrow(() -> jsonSchemaToConnectSchemaConverter.toConnectSchema(jsonSchema));
+
+        Object actualConnectValue =
+                jsonNodeToConnectValueConverter.toConnectValue(actualConnectSchema, jsonValue);
+        assertDoesNotThrow(() -> ConnectSchema.validateValue(actualConnectSchema, actualConnectValue));
+    }
+
+    @Test
+    public void testToConnect_constBooleanType_doesNotThrow() throws Exception {
+        JSONObject jsonSchemaObject = new JSONObject("{\n" +
+                "    \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n" +
+                "    \"type\": \"object\",\n" +
+                "    \"properties\": {\n" +
+                "        \"enabled\": { \"const\": true }\n" +
+                "    },\n" +
+                "    \"additionalProperties\": false\n" +
+                "}");
+
+        JSONObject jsonSubject = new JSONObject("{ \"enabled\": true }");
+
+        org.everit.json.schema.Schema jsonSchema =
+                org.everit.json.schema.loader.SchemaLoader.load(jsonSchemaObject);
+        assertDoesNotThrow(() -> jsonSchema.validate(jsonSubject));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonValue = objectMapper.readTree(jsonSubject.toString());
+
+        Schema actualConnectSchema =
+                assertDoesNotThrow(() -> jsonSchemaToConnectSchemaConverter.toConnectSchema(jsonSchema));
+        assertEquals(Schema.Type.BOOLEAN, actualConnectSchema.field("enabled").schema().type());
+
+        Object actualConnectValue =
+                jsonNodeToConnectValueConverter.toConnectValue(actualConnectSchema, jsonValue);
+        assertDoesNotThrow(() -> ConnectSchema.validateValue(actualConnectSchema, actualConnectValue));
+        assertEquals(true, ((Struct) actualConnectValue).get("enabled"));
+    }
+
     @ParameterizedTest
     @MethodSource(value = "com.amazonaws.services.schemaregistry.kafkaconnect.jsonschema.TestDataProvider#"
             + "testSchemaAndValueArgumentsProvider")

--- a/jsonschema-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/ToConnectTest.java
+++ b/jsonschema-kafkaconnect-converter/src/test/java/com/amazonaws/services/schemaregistry/kafkaconnect/jsonschema/ToConnectTest.java
@@ -33,6 +33,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.json.DecimalFormat;
 import org.everit.json.schema.ArraySchema;
 import org.everit.json.schema.BooleanSchema;
@@ -54,6 +55,8 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
@@ -143,96 +146,123 @@ public class ToConnectTest {
         assertDoesNotThrow(() -> ConnectSchema.validateValue(actualConnectSchema, actualConnectValue));
     }
 
-    @Test
-    public void testToConnect_constStringType_doesNotThrow() throws Exception {
-        // Customer feedback: JSON Schema "const" types are not supported by the Kafka
-        // Connect translation. everit parses "const" as a ConstSchema, which the
-        // TypeConverterFactory did not handle, producing:
-        //   DataException: Unsupported schema type org.everit.json.schema.ConstSchema
-        JSONObject jsonSchemaObject = new JSONObject("{\n" +
-                "    \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n" +
-                "    \"type\": \"object\",\n" +
-                "    \"properties\": {\n" +
-                "        \"country\": { \"const\": \"United States of America\" }\n" +
-                "    },\n" +
-                "    \"additionalProperties\": false\n" +
-                "}");
+    // ---------------------------------------------------------------------------------
+    // JSON Schema "const" support (draft-06+). A const may be any JSON value - scalar,
+    // object, or array - and everit surfaces it as a ConstSchema. The converter infers a
+    // Connect schema from the shape of the permitted value. These tests cover each shape
+    // plus the ambiguous cases that must fail fast with a clear error.
+    // ---------------------------------------------------------------------------------
 
-        JSONObject jsonSubject = new JSONObject("{ \"country\": \"United States of America\" }");
+    private Schema convertConstProperty(String constJson, String valueJson) throws Exception {
+        JSONObject jsonSchemaObject = new JSONObject("{"
+                + "\"$schema\": \"http://json-schema.org/draft-07/schema#\","
+                + "\"type\": \"object\","
+                + "\"properties\": { \"c\": " + constJson + " },"
+                + "\"additionalProperties\": false }");
 
         org.everit.json.schema.Schema jsonSchema =
                 org.everit.json.schema.loader.SchemaLoader.load(jsonSchemaObject);
-        assertDoesNotThrow(() -> jsonSchema.validate(jsonSubject));
 
+        Schema connectSchema = jsonSchemaToConnectSchemaConverter.toConnectSchema(jsonSchema);
+
+        // Also exercise the value path so we prove data actually deserializes, not just
+        // that the schema builds.
         ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode jsonValue = objectMapper.readTree(jsonSubject.toString());
+        JsonNode jsonValue = objectMapper.readTree("{ \"c\": " + valueJson + " }");
+        Object connectValue = jsonNodeToConnectValueConverter.toConnectValue(connectSchema, jsonValue);
+        ConnectSchema.validateValue(connectSchema, connectValue);
 
-        Schema actualConnectSchema =
-                assertDoesNotThrow(() -> jsonSchemaToConnectSchemaConverter.toConnectSchema(jsonSchema));
-        assertEquals(Schema.Type.STRING, actualConnectSchema.field("country").schema().type());
-
-        Object actualConnectValue =
-                jsonNodeToConnectValueConverter.toConnectValue(actualConnectSchema, jsonValue);
-        assertDoesNotThrow(() -> ConnectSchema.validateValue(actualConnectSchema, actualConnectValue));
-        assertEquals("United States of America", ((Struct) actualConnectValue).get("country"));
+        return connectSchema.field("c").schema();
     }
 
     @Test
-    public void testToConnect_constNumberType_doesNotThrow() throws Exception {
-        JSONObject jsonSchemaObject = new JSONObject("{\n" +
-                "    \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n" +
-                "    \"type\": \"object\",\n" +
-                "    \"properties\": {\n" +
-                "        \"version\": { \"const\": 1 }\n" +
-                "    },\n" +
-                "    \"additionalProperties\": false\n" +
-                "}");
-
-        JSONObject jsonSubject = new JSONObject("{ \"version\": 1 }");
-
-        org.everit.json.schema.Schema jsonSchema =
-                org.everit.json.schema.loader.SchemaLoader.load(jsonSchemaObject);
-        assertDoesNotThrow(() -> jsonSchema.validate(jsonSubject));
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode jsonValue = objectMapper.readTree(jsonSubject.toString());
-
-        Schema actualConnectSchema =
-                assertDoesNotThrow(() -> jsonSchemaToConnectSchemaConverter.toConnectSchema(jsonSchema));
-
-        Object actualConnectValue =
-                jsonNodeToConnectValueConverter.toConnectValue(actualConnectSchema, jsonValue);
-        assertDoesNotThrow(() -> ConnectSchema.validateValue(actualConnectSchema, actualConnectValue));
+    public void testToConnect_constString_mapsToString() throws Exception {
+        Schema fieldSchema = convertConstProperty("{ \"const\": \"US\" }", "\"US\"");
+        assertEquals(Schema.Type.STRING, fieldSchema.type());
     }
 
     @Test
-    public void testToConnect_constBooleanType_doesNotThrow() throws Exception {
-        JSONObject jsonSchemaObject = new JSONObject("{\n" +
-                "    \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n" +
-                "    \"type\": \"object\",\n" +
-                "    \"properties\": {\n" +
-                "        \"enabled\": { \"const\": true }\n" +
-                "    },\n" +
-                "    \"additionalProperties\": false\n" +
-                "}");
+    public void testToConnect_constInteger_mapsToInt64() throws Exception {
+        Schema fieldSchema = convertConstProperty("{ \"const\": 1 }", "1");
+        assertEquals(Schema.Type.INT64, fieldSchema.type());
+    }
 
-        JSONObject jsonSubject = new JSONObject("{ \"enabled\": true }");
+    @Test
+    public void testToConnect_constNumber_mapsToFloat64() throws Exception {
+        Schema fieldSchema = convertConstProperty("{ \"const\": 1.5 }", "1.5");
+        assertEquals(Schema.Type.FLOAT64, fieldSchema.type());
+    }
 
+    @Test
+    public void testToConnect_constBoolean_mapsToBoolean() throws Exception {
+        Schema fieldSchema = convertConstProperty("{ \"const\": true }", "true");
+        assertEquals(Schema.Type.BOOLEAN, fieldSchema.type());
+    }
+
+    @Test
+    public void testToConnect_constObject_mapsToStruct() throws Exception {
+        Schema fieldSchema = convertConstProperty(
+                "{ \"const\": { \"code\": \"US\", \"rank\": 1 } }",
+                "{ \"code\": \"US\", \"rank\": 1 }");
+        assertEquals(Schema.Type.STRUCT, fieldSchema.type());
+        assertEquals(Schema.Type.STRING, fieldSchema.field("code").schema().type());
+        assertEquals(Schema.Type.INT64, fieldSchema.field("rank").schema().type());
+    }
+
+    @Test
+    public void testToConnect_constArray_mapsToArrayOfElementType() throws Exception {
+        Schema fieldSchema = convertConstProperty("{ \"const\": [\"a\", \"b\"] }", "[\"a\", \"b\"]");
+        assertEquals(Schema.Type.ARRAY, fieldSchema.type());
+        assertEquals(Schema.Type.STRING, fieldSchema.valueSchema().type());
+    }
+
+    @Test
+    public void testToConnect_constNestedObjectAndArray_mapsRecursively() throws Exception {
+        Schema fieldSchema = convertConstProperty(
+                "{ \"const\": { \"name\": \"x\", \"tags\": [\"a\", \"b\"] } }",
+                "{ \"name\": \"x\", \"tags\": [\"a\", \"b\"] }");
+        assertEquals(Schema.Type.STRUCT, fieldSchema.type());
+        assertEquals(Schema.Type.STRING, fieldSchema.field("name").schema().type());
+        assertEquals(Schema.Type.ARRAY, fieldSchema.field("tags").schema().type());
+        assertEquals(Schema.Type.STRING, fieldSchema.field("tags").schema().valueSchema().type());
+    }
+
+    @Test
+    public void testToConnect_constObjectValue_deserializesToStruct() throws Exception {
+        JSONObject jsonSchemaObject = new JSONObject("{"
+                + "\"$schema\": \"http://json-schema.org/draft-07/schema#\","
+                + "\"type\": \"object\","
+                + "\"properties\": { \"region\": { \"const\": { \"code\": \"US\", \"rank\": 1 } } },"
+                + "\"additionalProperties\": false }");
         org.everit.json.schema.Schema jsonSchema =
                 org.everit.json.schema.loader.SchemaLoader.load(jsonSchemaObject);
-        assertDoesNotThrow(() -> jsonSchema.validate(jsonSubject));
 
         ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode jsonValue = objectMapper.readTree(jsonSubject.toString());
+        JsonNode jsonValue = objectMapper.readTree("{ \"region\": { \"code\": \"US\", \"rank\": 1 } }");
 
-        Schema actualConnectSchema =
-                assertDoesNotThrow(() -> jsonSchemaToConnectSchemaConverter.toConnectSchema(jsonSchema));
-        assertEquals(Schema.Type.BOOLEAN, actualConnectSchema.field("enabled").schema().type());
+        Schema connectSchema = jsonSchemaToConnectSchemaConverter.toConnectSchema(jsonSchema);
+        Object connectValue = jsonNodeToConnectValueConverter.toConnectValue(connectSchema, jsonValue);
 
-        Object actualConnectValue =
-                jsonNodeToConnectValueConverter.toConnectValue(actualConnectSchema, jsonValue);
-        assertDoesNotThrow(() -> ConnectSchema.validateValue(actualConnectSchema, actualConnectValue));
-        assertEquals(true, ((Struct) actualConnectValue).get("enabled"));
+        assertDoesNotThrow(() -> ConnectSchema.validateValue(connectSchema, connectValue));
+        Struct region = (Struct) ((Struct) connectValue).get("region");
+        assertEquals("US", region.get("code"));
+        assertEquals(1L, region.get("rank"));
+    }
+
+    @Test
+    public void testToConnect_constEmptyArray_throwsClearError() {
+        DataException ex = assertThrows(DataException.class,
+                () -> convertConstProperty("{ \"const\": [] }", "[]"));
+        assertTrue(ex.getMessage().contains("empty 'const' array"),
+                "Unexpected message: " + ex.getMessage());
+    }
+
+    @Test
+    public void testToConnect_constHeterogeneousArray_throwsClearError() {
+        DataException ex = assertThrows(DataException.class,
+                () -> convertConstProperty("{ \"const\": [\"a\", 1] }", "[\"a\", 1]"));
+        assertTrue(ex.getMessage().contains("heterogeneous 'const' array"),
+                "Unexpected message: " + ex.getMessage());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Description

Adds support for JSON Schema `const` types to the Kafka Connect JSON Schema
converter. Reported via customer feedback: the Kafka Connect translation failed
on schemas using `const`.

## Problem

On `master`, any `const` schema fails immediately with:

```
org.apache.kafka.connect.errors.DataException:
    Unsupported schema type org.everit.json.schema.ConstSchema
```

## Approach (reworked per review feedback)

A `const` restricts a value to a single permitted value, which per draft-06+ may
be **any** JSON value — scalar, object, or array. everit exposes it as a
`ConstSchema` whose `getPermittedValue()` returns the value with its natural Java
type (`String`, `Integer`, `Boolean`, `Map`, `List`, ...).

The converter now handles `ConstSchema` in `JsonSchemaToConnectSchemaConverter`
by **recursively inferring** a Connect schema from the shape of the permitted
value:

- scalar → matching Connect type (`STRING`, `INT64`, `FLOAT64`, `BOOLEAN`)
- object (`Map`) → `STRUCT`, recursing per field (fields sorted for deterministic order)
- array (`Collection`) → `ARRAY` with a homogeneous element type, recursing on the element

Because value deserialization is driven by the Connect schema type, routing
through the normal type machinery means both schema translation **and** value
deserialization work for objects and arrays — not just scalars.

Ambiguous cases that cannot map to a Connect schema fail fast with a clear,
specific message instead of a misleading downstream error:

- empty `const` array (no element type to infer)
- heterogeneous `const` array (Connect `ARRAY` requires a single element type)
- `null` const value / `null` object-field value (no inferable type)

### Scope / honest limitation

This preserves the **type** of the const value so data flows through correctly.
It does **not** enforce the const **constraint** (that the value must equal the
permitted value), and the constraint is not round-tripped back to `const` — Connect's
schema model has no equality constraint. This is consistent with how the converter
already treats other JSON Schema validation keywords (`pattern`, `minimum`,
`format`, ...): the type is kept, the constraint is dropped.

## What changed since the first version of this PR

The initial version mapped `const` in `TypeConverterFactory` using only the
scalar Java type, which (correctly flagged in review) mis-typed object/array
consts as `STRING` and produced a confusing downstream
`Invalid null value for required STRING field` — strictly worse than master's
clear "unsupported" error. That approach has been fully reverted; `const` is now
handled at the schema-construction layer with recursive inference, and the
object/array cases are covered by tests.

## Testing

Added tests in `ToConnectTest` covering each shape and the fail-fast cases:
string, integer, number, boolean, object→STRUCT, array→ARRAY, nested
object+array, object-value deserialization into a `Struct`, and expected
`DataException`s for empty and heterogeneous arrays.

- `mvn -pl jsonschema-kafkaconnect-converter test` — 339 tests, 0 failures.
- `mvn clean verify` — BUILD SUCCESS across all 13 modules.
