### PR TITLE
Cache parsed Avro Schema to fix performance issue (fixes #478)

### DIFF
--- a/avro-flink-serde/src/main/java/com/amazonaws/services/schemaregistry/flink/avro/GlueSchemaRegistryInputStreamDeserializer.java
+++ b/avro-flink-serde/src/main/java/com/amazonaws/services/schemaregistry/flink/avro/GlueSchemaRegistryInputStreamDeserializer.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 
 /**
@@ -35,6 +36,7 @@ import java.util.Map;
  */
 public class GlueSchemaRegistryInputStreamDeserializer {
     private final GlueSchemaRegistryDeserializationFacade glueSchemaRegistryDeserializationFacade;
+    private final ConcurrentHashMap<String, Schema> parsedSchemaCache = new ConcurrentHashMap<>();
 
     /**
      * Constructor accepts configuration map for AWS Deserializer
@@ -69,13 +71,14 @@ public class GlueSchemaRegistryInputStreamDeserializer {
         byte[] deserializedBytes = glueSchemaRegistryDeserializationFacade.getActualData(inputBytes);
         mutableByteArrayInputStream.setBuffer(deserializedBytes);
 
-        Schema schema;
-        try {
-            schema = (new Schema.Parser()).parse(schemaDefinition);
-        } catch (SchemaParseException e) {
-            String message = "Error occurred while parsing schema, see inner exception for details.";
-            throw new AWSSchemaRegistryException(message, e);
-        }
+        Schema schema = parsedSchemaCache.computeIfAbsent(schemaDefinition, schemaDef -> {
+            try {
+                return (new Schema.Parser()).parse(schemaDef);
+            } catch (SchemaParseException e) {
+                String message = "Error occurred while parsing schema, see inner exception for details.";
+                throw new AWSSchemaRegistryException(message, e);
+            }
+        });
 
         return schema;
     }

--- a/avro-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/AWSKafkaAvroConverter.java
+++ b/avro-kafkaconnect-converter/src/main/java/com/amazonaws/services/schemaregistry/kafkaconnect/AWSKafkaAvroConverter.java
@@ -37,6 +37,7 @@ import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Amazon Schema Registry Avro converter for Kafka Connect users.
@@ -48,6 +49,7 @@ public class AWSKafkaAvroConverter implements Converter {
     private AWSKafkaAvroSerializer serializer;
     private AWSKafkaAvroDeserializer deserializer;
     private AvroData avroData;
+    private final ConcurrentHashMap<String, org.apache.avro.Schema> parsedSchemaCache = new ConcurrentHashMap<>();
 
     private boolean isKey;
 
@@ -155,14 +157,13 @@ public class AWSKafkaAvroConverter implements Converter {
      */
     @VisibleForTesting
     protected org.apache.avro.Schema extractAvroSchema(final byte[] value, final Object deserialized) {
-        final org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
-
         // Check if this is GSR data that can be processed by GSR deserialization facade
         if (deserializer.getGlueSchemaRegistryDeserializationFacade().canDeserialize(value)) {
             // GSR data: extract schema from registry metadata
             try {
                 final String schemaDefinition = deserializer.getGlueSchemaRegistryDeserializationFacade().getSchemaDefinition(value);
-                return parser.parse(schemaDefinition);
+                return parsedSchemaCache.computeIfAbsent(schemaDefinition,
+                    schemaDef -> new org.apache.avro.Schema.Parser().parse(schemaDef));
             } catch (final Exception e) {
                 throw new DataException("Failed to extract schema from GSR metadata", e);
             }


### PR DESCRIPTION
## Summary
Adds a ConcurrentHashMap cache for parsed `org.apache.avro.Schema` objects in the Flink and Kafka Connect Avro deserializers. This avoids calling `Schema.Parser().parse()` on every event, which was identified as a 3.5-4x performance bottleneck in #478.

## Changes
- **avro-flink-serde**: `GlueSchemaRegistryInputStreamDeserializer` now caches parsed schemas keyed by schema definition string
- **avro-kafkaconnect-converter**: `AWSKafkaAvroConverter` now caches parsed schemas keyed by schema definition string

## Testing
- All existing unit tests pass (22 tests in avro-kafkaconnect-converter, 20 tests in avro-flink-serde)
- No API changes, drop-in behavioral improvement

Fixes #478