### PR TITLE
feat(json): add opt-out for className-based deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,3 +106,6 @@ GlueSchemaRegistryKafkaSerializer/GlueSchemaRegistryKafkaDeserializer.
 ## Release 1.1.27
 * Introduce lz4 shim and dependency upgrade to fix vulnerabilities
 * Updated local integration tests to make requests to local stack syncrounysly to correct for flakyness
+
+## Release 1.1.28
+* JSON deserializer no longer resolves the schema's `className` field into a POJO by default; it now returns `JsonDataWithSchema` unless `jsonClassNameResolutionEnabled` is set to `true`. This is a breaking change for consumers that relied on automatic POJO deserialization.

--- a/avro-flink-serde/pom.xml
+++ b/avro-flink-serde/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>software.amazon.glue</groupId>
     <artifactId>schema-registry-flink-serde</artifactId>
-    <version>1.1.27</version>
+    <version>1.1.28</version>
     <name>AWS Glue Schema Registry Flink Avro Serialization Deserialization Schema</name>
     <description>The AWS Glue Schema Registry Library for Apache Flink enables Java developers to easily integrate
         their Apache Flink applications with AWS Glue Schema Registry
@@ -31,7 +31,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.27</version>
+        <version>1.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-serde</artifactId>
-            <version>1.1.27</version>
+            <version>1.1.28</version>
         </dependency>
         <dependency>
           <groupId>org.projectlombok</groupId>

--- a/avro-kafkaconnect-converter/pom.xml
+++ b/avro-kafkaconnect-converter/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-    <version>1.1.27</version>
+    <version>1.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-    <version>1.1.27</version>
+    <version>1.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-    <version>1.1.27</version>
+    <version>1.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfiguration.java
@@ -54,6 +54,7 @@ public class GlueSchemaRegistryConfiguration {
     private Compatibility compatibilitySetting;
     private String description;
     private boolean schemaAutoRegistrationEnabled = false;
+    private boolean jsonClassNameResolutionEnabled = false;
     private Map<String, String> tags = new HashMap<>();
     private Map<String, String> metadata;
     private String secondaryDeserializer;
@@ -97,6 +98,7 @@ public class GlueSchemaRegistryConfiguration {
         validateAndSetCompatibility(configs);
         validateAndSetCompressionType(configs);
         validateAndSetSchemaAutoRegistrationSetting(configs);
+        validateAndSetJsonClassNameResolutionSetting(configs);
         validateAndSetJacksonSerializationFeatures(configs);
         validateAndSetJacksonDeserializationFeatures(configs);
         validateAndSetTags(configs);
@@ -267,6 +269,17 @@ public class GlueSchemaRegistryConfiguration {
         } else {
             log.info("schemaAutoRegistrationEnabled is not defined in the properties. Using the default value {}",
                      schemaAutoRegistrationEnabled);
+        }
+    }
+
+    private void validateAndSetJsonClassNameResolutionSetting(Map<String, ?> configs) {
+        if (isPresent(configs, AWSSchemaRegistryConstants.JSON_CLASS_NAME_RESOLUTION_ENABLED)) {
+            this.jsonClassNameResolutionEnabled = Boolean.parseBoolean(
+                    configs.get(AWSSchemaRegistryConstants.JSON_CLASS_NAME_RESOLUTION_ENABLED)
+                            .toString());
+        } else {
+            log.info("jsonClassNameResolutionEnabled is not defined in the properties. Using the default value {}",
+                     jsonClassNameResolutionEnabled);
         }
     }
 

--- a/common/src/main/java/com/amazonaws/services/schemaregistry/utils/AWSSchemaRegistryConstants.java
+++ b/common/src/main/java/com/amazonaws/services/schemaregistry/utils/AWSSchemaRegistryConstants.java
@@ -173,6 +173,17 @@ public final class AWSSchemaRegistryConstants {
     public static final String USER_AGENT_APP = "userAgentApp";
 
     /**
+     * Controls whether the JSON deserializer resolves the target class from the
+     * {@code className} field embedded in the schema and deserializes into that
+     * POJO via reflection. Defaults to {@code false} so that untrusted schemas
+     * cannot drive instantiation of arbitrary classes; the deserializer returns
+     * a {@code JsonDataWithSchema} regardless of the presence of
+     * {@code className}. Set to {@code true} to opt in to the legacy behavior of
+     * deserializing into the class named by the schema's {@code className} field.
+     */
+    public static final String JSON_CLASS_NAME_RESOLUTION_ENABLED = "jsonClassNameResolutionEnabled";
+
+    /**
      * IAM Role ARN to assume for accessing the registry
      */
     public static final String ASSUME_ROLE_ARN = "assumeRoleArn";

--- a/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
+++ b/common/src/test/java/com/amazonaws/services/schemaregistry/common/configs/GlueSchemaRegistryConfigurationTest.java
@@ -34,6 +34,7 @@ import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -410,5 +411,40 @@ public class GlueSchemaRegistryConfigurationTest {
         props.put(AWSSchemaRegistryConstants.PROXY_URL, "http:// proxy.url: 8080");
         Exception exception = assertThrows(AWSSchemaRegistryException.class, () -> new GlueSchemaRegistryConfiguration(props));
         assertEquals("Proxy URL property is not a valid URL: "+proxy, exception.getMessage());
+    }
+
+    /**
+     * Tests that JSON class name resolution defaults to disabled (secure default) when not configured.
+     */
+    @Test
+    public void testJsonClassNameResolution_withoutConfig_defaultsToDisabled() {
+        Properties props = createTestProperties();
+        GlueSchemaRegistryConfiguration glueSchemaRegistryConfiguration = new GlueSchemaRegistryConfiguration(props);
+
+        assertFalse(glueSchemaRegistryConfiguration.isJsonClassNameResolutionEnabled());
+    }
+
+    /**
+     * Tests that customers can opt in to JSON class name resolution.
+     */
+    @Test
+    public void testJsonClassNameResolution_setToTrue_isEnabled() {
+        Properties props = createTestProperties();
+        props.put(AWSSchemaRegistryConstants.JSON_CLASS_NAME_RESOLUTION_ENABLED, "true");
+        GlueSchemaRegistryConfiguration glueSchemaRegistryConfiguration = new GlueSchemaRegistryConfiguration(props);
+
+        assertTrue(glueSchemaRegistryConfiguration.isJsonClassNameResolutionEnabled());
+    }
+
+    /**
+     * Tests that JSON class name resolution can be explicitly disabled.
+     */
+    @Test
+    public void testJsonClassNameResolution_setToFalse_isDisabled() {
+        Properties props = createTestProperties();
+        props.put(AWSSchemaRegistryConstants.JSON_CLASS_NAME_RESOLUTION_ENABLED, "false");
+        GlueSchemaRegistryConfiguration glueSchemaRegistryConfiguration = new GlueSchemaRegistryConfiguration(props);
+
+        assertFalse(glueSchemaRegistryConfiguration.isJsonClassNameResolutionEnabled());
     }
 }

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-    <version>1.1.27</version>
+    <version>1.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-    <version>1.1.27</version>
+    <version>1.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jsonschema-kafkaconnect-converter/pom.xml
+++ b/jsonschema-kafkaconnect-converter/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-    <version>1.1.27</version>
+    <version>1.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kafkastreams-serde/pom.xml
+++ b/kafkastreams-serde/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-    <version>1.1.27</version>
+    <version>1.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/multilang-schema-registry/pom.xml
+++ b/multilang-schema-registry/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-        <version>1.1.27</version>
+        <version>1.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>software.amazon.glue</groupId>
     <artifactId>schema-registry-parent</artifactId>
-    <version>1.1.27</version>
+    <version>1.1.28</version>
     <packaging>pom</packaging>
     <name>AWS Glue Schema Registry Library</name>
     <description>The AWS Glue Schema Registry Library for Java enables Java developers to easily integrate their

--- a/protobuf-kafkaconnect-converter/pom.xml
+++ b/protobuf-kafkaconnect-converter/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-    <version>1.1.27</version>
+    <version>1.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/serializer-deserializer-msk-iam/pom.xml
+++ b/serializer-deserializer-msk-iam/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-    <version>1.1.27</version>
+    <version>1.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/serializer-deserializer/pom.xml
+++ b/serializer-deserializer/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>software.amazon.glue</groupId>
         <artifactId>schema-registry-parent</artifactId>
-    <version>1.1.27</version>
+    <version>1.1.28</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializer.java
+++ b/serializer-deserializer/src/main/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializer.java
@@ -94,7 +94,10 @@ public class JsonDeserializer implements GlueSchemaRegistryDataFormatDeserialize
             JsonNode schemaNode = objectMapper.readTree(schema);
             JsonNode classNameNode = schemaNode.get("className");
 
-            if (classNameNode != null) {
+            boolean classNameResolutionEnabled = schemaRegistrySerDeConfigs != null
+                    && schemaRegistrySerDeConfigs.isJsonClassNameResolutionEnabled();
+
+            if (classNameResolutionEnabled && classNameNode != null) {
                 String className = classNameNode.asText();
                 deserializedObject = objectMapper.readValue(data, Class.forName(className));
             } else {

--- a/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializerTest.java
+++ b/serializer-deserializer/src/test/java/com/amazonaws/services/schemaregistry/deserializers/json/JsonDeserializerTest.java
@@ -14,36 +14,119 @@
  */
 package com.amazonaws.services.schemaregistry.deserializers.json;
 
+import com.amazonaws.services.schemaregistry.common.Schema;
+import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
+import com.amazonaws.services.schemaregistry.serializers.json.Car;
+import com.amazonaws.services.schemaregistry.serializers.json.JsonDataWithSchema;
+import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.glue.model.DataFormat;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import com.amazonaws.services.schemaregistry.common.Schema;
-import software.amazon.awssdk.services.glue.model.DataFormat;
+import java.util.HashMap;
+import java.util.Map;
 
-import java.util.UUID;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JsonDeserializerTest {
-    private JsonDeserializer jsonDeserializer = new JsonDeserializer(null);
+    private static final String GEOLOCATION_SCHEMA =
+            "{\"$id\":\"https://example.com/geographical-location.schema.json\","
+            + "\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"title\":\"Longitude "
+            + "and Latitude Values\",\"description\":\"A geographical coordinate.\","
+            + "\"required\":[\"latitude\",\"longitude\"],\"type\":\"object\","
+            + "\"properties\":{\"latitude\":{\"type\":\"number\",\"minimum\":-90,"
+            + "\"maximum\":90},\"longitude\":{\"type\":\"number\",\"minimum\":-180,"
+            + "\"maximum\":180}},\"additionalProperties\":false}";
+    private static final String GEOLOCATION_PAYLOAD = "{\"latitude\":48.858093,\"longitude\":2.294694}";
+
+    private static final String CAR_SCHEMA =
+            "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"title\":\"Simple Car "
+            + "Schema\",\"type\":\"object\",\"additionalProperties\":false,"
+            + "\"description\":\"This is a car\",\"className\":\"com.amazonaws.services"
+            + ".schemaregistry.serializers.json.Car\","
+            + "\"properties\":{\"make\":{\"type\":\"string\"},\"model\":{\"type\":\"string\"}}}";
+    private static final String CAR_PAYLOAD = "{\"make\":\"Honda\",\"model\":\"Civic\"}";
+
+    private final JsonDeserializer jsonDeserializer = new JsonDeserializer(null);
+
+    /**
+     * Wraps the raw payload bytes in the Glue Schema Registry header so they can be
+     * fed to {@link JsonDeserializer#deserialize}.
+     */
+    private static ByteBuffer toSerializedBuffer(String payload) {
+        byte[] data = payload.getBytes(StandardCharsets.UTF_8);
+        ByteBuffer byteBuffer = ByteBuffer.allocate(18 + data.length);
+        byteBuffer.put(AWSSchemaRegistryConstants.HEADER_VERSION_BYTE);
+        byteBuffer.put(AWSSchemaRegistryConstants.COMPRESSION_DEFAULT_BYTE);
+        // Schema version id (128-bit UUID) - value irrelevant for these tests.
+        byteBuffer.putLong(0L);
+        byteBuffer.putLong(0L);
+        byteBuffer.put(data);
+        byteBuffer.rewind();
+        return byteBuffer;
+    }
+
+    private static JsonDeserializer deserializerWithClassNameResolution(boolean enabled) {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(AWSSchemaRegistryConstants.AWS_REGION, "us-east-1");
+        configs.put(AWSSchemaRegistryConstants.JSON_CLASS_NAME_RESOLUTION_ENABLED, String.valueOf(enabled));
+        return new JsonDeserializer(new GlueSchemaRegistryConfiguration(configs));
+    }
 
     @Test
     public void testDeserialize_nullArgs_throwsException() {
-        String testSchemaDefinition = "{\"$id\":\"https://example.com/geographical-location.schema.json\","
-                                      + "\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"title\":\"Longitude "
-                                      + "and Latitude Values\",\"description\":\"A geographical coordinate.\","
-                                      + "\"required\":[\"latitude\",\"longitude\"],\"type\":\"object\","
-                                      + "\"properties\":{\"latitude\":{\"type\":\"number\",\"minimum\":-90,"
-                                      + "\"maximum\":90},\"longitude\":{\"type\":\"number\",\"minimum\":-180,"
-                                      + "\"maximum\":180}},\"additionalProperties\":false}";
-        String jsonData = "{\"latitude\":48.858093,\"longitude\":2.294694}";
-        byte[] testBytes = jsonData.getBytes(StandardCharsets.UTF_8);
-
-        Schema testSchema = new Schema(testSchemaDefinition, DataFormat.JSON.name(), "testJson");
+        Schema testSchema = new Schema(GEOLOCATION_SCHEMA, DataFormat.JSON.name(), "testJson");
+        byte[] testBytes = GEOLOCATION_PAYLOAD.getBytes(StandardCharsets.UTF_8);
 
         assertThrows(IllegalArgumentException.class, () -> jsonDeserializer.deserialize(null, testSchema));
         assertThrows(IllegalArgumentException.class, () -> jsonDeserializer.deserialize(ByteBuffer.wrap(testBytes),
                                                                                         null));
+    }
+
+    @Test
+    public void testDeserialize_schemaWithoutClassName_returnsJsonDataWithSchema() {
+        Schema schema = new Schema(GEOLOCATION_SCHEMA, DataFormat.JSON.name(), "testJson");
+
+        Object result = jsonDeserializer.deserialize(toSerializedBuffer(GEOLOCATION_PAYLOAD), schema);
+
+        assertTrue(result instanceof JsonDataWithSchema);
+    }
+
+    @Test
+    public void testDeserialize_schemaWithClassName_defaultConfig_returnsJsonDataWithSchema() {
+        Schema schema = new Schema(CAR_SCHEMA, DataFormat.JSON.name(), "testJson");
+
+        // No config supplied (null) -> class name resolution defaults to disabled (secure default),
+        // so the schema's className is ignored and a generic JsonDataWithSchema is returned.
+        Object result = jsonDeserializer.deserialize(toSerializedBuffer(CAR_PAYLOAD), schema);
+
+        assertTrue(result instanceof JsonDataWithSchema);
+        assertEquals(CAR_PAYLOAD, ((JsonDataWithSchema) result).getPayload());
+    }
+
+    @Test
+    public void testDeserialize_schemaWithClassName_resolutionEnabled_returnsSpecificPojo() {
+        JsonDeserializer deserializer = deserializerWithClassNameResolution(true);
+        Schema schema = new Schema(CAR_SCHEMA, DataFormat.JSON.name(), "testJson");
+
+        Object result = deserializer.deserialize(toSerializedBuffer(CAR_PAYLOAD), schema);
+
+        assertTrue(result instanceof Car);
+    }
+
+    @Test
+    public void testDeserialize_schemaWithClassName_resolutionDisabled_returnsJsonDataWithSchema() {
+        JsonDeserializer deserializer = deserializerWithClassNameResolution(false);
+        Schema schema = new Schema(CAR_SCHEMA, DataFormat.JSON.name(), "testJson");
+
+        // Customer opted out of className resolution -> generic JsonDataWithSchema even though
+        // the schema carries a className.
+        Object result = deserializer.deserialize(toSerializedBuffer(CAR_PAYLOAD), schema);
+
+        assertTrue(result instanceof JsonDataWithSchema);
+        assertEquals(CAR_PAYLOAD, ((JsonDataWithSchema) result).getPayload());
     }
 }


### PR DESCRIPTION
*Description of changes:*

The JSON deserializer resolves a target class from the `className` field embedded in the schema and deserialized the payload into that class via reflection (`Class.forName(...)` + `ObjectMapper.readValue(...)`). This means an untrusted or tampered schema could drive instantiation of an arbitrary class on the consumer's classpath.

This PR adds a `jsonClassNameResolutionEnabled` configuration flag that **defaults to `false`**. With the default, the deserializer ignores `className` and always returns a `JsonDataWithSchema`. Consumers that want the previous POJO-resolution behavior must explicitly opt in by setting the flag to `true`.

> **Recommended:** The target class should be supplied by the application at configuration time, not derived from schema metadata at runtime.

## ⚠️ Breaking change

Consumers that relied on automatic POJO deserialization (a schema carrying `className` producing a typed object) will now receive a `JsonDataWithSchema` instead. To restore the previous behavior:

```java
Map<String, Object> configs = new HashMap<>();
configs.put(AWSSchemaRegistryConstants.JSON_CLASS_NAME_RESOLUTION_ENABLED, "true");
// ... build the deserializer/config as usual

*Issue #, if available:*
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
