### PR TITLE
Fix/integ test docker images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ integration-tests/volume/lib/kinesis-local/0.4.12/package-lock.json
 integration-tests/volume/cache/server.test.pem.crt
 integration-tests/volume/cache/server.test.pem.key
 integration-tests/volume/lib/kinesis-local/0.4.12/package.json
+integration-tests/volume/lib/kinesis-local/0.5.2
 
 multilang-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/glue_schema_registry_deserializer.cs
 multilang-schema-registry/csharp/AWSGsrSerDe/AWSGsrSerDe/glue_schema_registry_schema.cs

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -1,26 +1,26 @@
-version: '2'
-
 services:
   zookeeper:
-    image: 'public.ecr.aws/bitnami/zookeeper:latest'
+    image: 'confluentinc/cp-zookeeper:7.6.0'
     ports:
-      - '2181:2182'
+      - '2181:2181'
     environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
-    image: 'public.ecr.aws/bitnami/kafka:2.8'
+    image: 'confluentinc/cp-kafka:7.6.0'
     ports:
       - '9092:9092'
-    links:
+    depends_on:
       - zookeeper
     container_name: local_kafka
     environment:
-      - KAFKA_BROKER_ID=1
-      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
-      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092
-      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092
-      - ALLOW_PLAINTEXT_LISTENER=yes
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"


### PR DESCRIPTION
The public.ecr.aws/bitnami/zookeeper and bitnami/kafka images are no longer available (ECR repo deleted, Docker Hub manifests missing). Replace with confluentinc/cp-zookeeper:7.6.0 and cp-kafka:7.6.0.

Also fixes:
- Zookeeper port mapping (2181:2182 -> 2181:2181)
- Remove deprecated docker-compose 'version' and 'links' directives
- Add kinesis-local 0.5.2 to .gitignore