### PR TITLE
fix(integration-tests): tolerate ResourceInUseException in Kinesis setUp

### DIFF
--- a/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kinesis/GlueSchemaRegistryKinesisIntegrationTest.java
+++ b/integration-tests/src/test/java/com/amazonaws/services/schemaregistry/integrationtests/kinesis/GlueSchemaRegistryKinesisIntegrationTest.java
@@ -70,6 +70,7 @@ import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
 import software.amazon.awssdk.services.kinesis.model.PutRecordRequest;
 import software.amazon.awssdk.services.kinesis.model.Record;
+import software.amazon.awssdk.services.kinesis.model.ResourceInUseException;
 import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
 import software.amazon.awssdk.services.kinesis.model.StreamStatus;
 import software.amazon.kinesis.common.ConfigsBuilder;
@@ -256,8 +257,21 @@ public class GlueSchemaRegistryKinesisIntegrationTest {
                 .streamName(streamName)
                 .shardCount(SHARD_COUNT)
                 .build();
-        kinesisClient.createStream(createStreamRequest)
-                .get();
+        try {
+            kinesisClient.createStream(createStreamRequest)
+                    .get();
+        } catch (ExecutionException e) {
+            // CreateStream is not idempotent and carries no idempotency token. If the first
+            // attempt is slow enough that the SDK classifies it as a retryable failure, the
+            // retry is a second, genuinely new create, and it reports ResourceInUseException
+            // even though the original attempt succeeded server-side. The postcondition this
+            // fixture needs is that the stream exists, and that exception is evidence it does,
+            // so it is not a failure. The Awaitility barrier below still gates on ACTIVE.
+            if (!(e.getCause() instanceof ResourceInUseException)) {
+                throw e;
+            }
+            LOGGER.info("Kinesis Stream {} already exists; a create was retried. Continuing.", streamName);
+        }
         Awaitility.await()
                 .until(() -> StreamStatus.ACTIVE.equals(kinesisClient.describeStream(DescribeStreamRequest.builder()
                                                                                              .streamName(streamName)


### PR DESCRIPTION
GlueSchemaRegistryKinesisIntegrationTest.setUp fails intermittently with

  ResourceInUseException: Stream gsr-integ-test-kinesis-stream-XXXX
  already exists (Status Code: 400) (SDK Attempt Count: 2)

LocalStack installs its Kinesis backend (kinesis-local) from npm lazily, on the first Kinesis API call, and that install blocks the call. When it is slow enough, the SDK classifies the outstanding CreateStream as a retryable failure and issues a second attempt. CreateStream is not idempotent and has no idempotency token, so the retry is a genuinely new create and is answered ResourceInUseException -- even though the first attempt had already succeeded server-side. setUp treated that as fatal.

Reference for the exception: https://docs.aws.amazon.com/java/api/latest/software/amazon/awssdk/services/kinesis/model/ResourceInUseException.html

The postcondition setUp needs is that the stream exists, and ResourceInUseException is evidence that it does. Treat it as success and let the existing Awaitility barrier continue to gate on StreamStatus .ACTIVE. Any other cause is rethrown unchanged.

This is correct against real Kinesis as well as LocalStack: the real service answers a duplicate CreateStream the same way.

Observed on the AWS-internal GSR Java client canary, which runs this module every 20 minutes: ~3% of runs failed this way over three weeks after npm install latency for kinesis-local stepped from ~2s to ~5s (tail to 12s) on 2026-07-20.

*Issue #, if available:*
N/A - it fixes the intermittent java integ test failures

*Test results*
```
11 Aug 2026 21:57:53,551 [INFO] (main) GlueSchemaRegistryKinesisIntegrationTest: Creating Kinesis Stream : gsr-integ-test-kinesis-stream-rKHV with 1 shards on localStack..
11 Aug 2026 21:57:54,515 [INFO] (main) GlueSchemaRegistryKinesisIntegrationTest: Finished creating Kinesis Stream : gsr-integ-test-kinesis-stream-rKHV
11 Aug 2026 21:58:16,174 [INFO] (main) GlueSchemaRegistryKinesisIntegrationTest: Creating Kinesis Stream : gsr-integ-test-kinesis-stream-TeVJ with 1 shards on localStack..
11 Aug 2026 21:58:16,751 [INFO] (main) GlueSchemaRegistryKinesisIntegrationTest: Finished creating Kinesis Stream : gsr-integ-test-kinesis-stream-TeVJ
11 Aug 2026 21:58:38,302 [INFO] (main) GlueSchemaRegistryKinesisIntegrationTest: Creating Kinesis Stream : gsr-integ-test-kinesis-stream-0qtN with 1 shards on localStack..
11 Aug 2026 21:58:38,855 [INFO] (main) GlueSchemaRegistryKinesisIntegrationTest: Finished creating Kinesis Stream : gsr-integ-test-kinesis-stream-0qtN

[INFO] Running com.amazonaws.services.schemaregistry.integrationtests.kafka.GlueSchemaRegistryKafkaIntegrationTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 17.756 s - in com.amazonaws.services.schemaregistry.integrationtests.kafka.GlueSchemaRegistryKafkaIntegrationTest
[INFO] Running com.amazonaws.services.schemaregistry.integrationtests.kinesis.GlueSchemaRegistryKinesisIntegrationTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 67.8 s - in com.amazonaws.services.schemaregistry.integrationtests.kinesis.GlueSchemaRegistryKinesisIntegrationTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0

11 Aug 2026 21:59:00,652 [INFO] (main) GlueSchemaRegistryKinesisIntegrationTest: Finished Cleaning up 3 schemas created with GSR.
[main] INFO GlueSchemaRegistryKafkaIntegrationTest - Finished Cleaning up 3 schemas created with GSR.

[INFO] BUILD SUCCESS
[INFO] Total time:  02:57 min
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
