### PR TITLE
security: pin Actions to SHAs, add Dependabot, add zizmor CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "nuget"
+    directory: "/multilang-schema-registry/csharp/AWSGsrSerDe"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "nuget"
     directory: "/multilang-schema-registry/csharp/AWSGsrSerDe"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/MavenCI.yml
+++ b/.github/workflows/MavenCI.yml
@@ -41,6 +41,7 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
+        lookup-only: true
 
     - name: Clean, build and install
       run: mvn --file pom.xml clean install

--- a/.github/workflows/MavenCI.yml
+++ b/.github/workflows/MavenCI.yml
@@ -9,6 +9,9 @@ on:
     branches: [ master ]
     types: [ created ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.operating-system }}
@@ -22,16 +25,18 @@ jobs:
         java-version: ['8', '11', '17']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        persist-credentials: false
 
     - name: Set up JDK ${{ matrix.java-version }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
       with:
         distribution: 'corretto'
         java-version: ${{ matrix.java-version }}
 
     - name: Cache Maven packages
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/build-csharp.yml
+++ b/.github/workflows/build-csharp.yml
@@ -9,15 +9,19 @@ on:
     branches: [ master ]
     types: [ created ]
 
+permissions:
+  contents: read
+
 jobs:
   git-secrets-scan:
     runs-on: ubuntu-latest
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install git-secrets
         run: |
@@ -105,8 +109,10 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         
+        with:
+          persist-credentials: false
       - name: Install CMake and dependencies
         shell: bash
         run: |
@@ -131,7 +137,7 @@ jobs:
           ${{ matrix.dotnet_setup }}
 
       - name: Set up Java
-        uses: graalvm/setup-graalvm@v1
+        uses: graalvm/setup-graalvm@5298d94fb55a4f185c602eeac5de1b553882abe2 # v1.6.4
         with:
           distribution: 'graalvm'
           java-version: '21.0.2'       
@@ -198,12 +204,13 @@ jobs:
         arch: [x64]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          persist-credentials: false
         
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         
       - name: Build GraalVM musl container
         run: |

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,31 @@
+name: Check GitHub Actions
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Check GitHub Actions security
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        with:
+          advanced-security: ${{ github.event_name == 'push' && 'true' || 'false' }}
+          min-severity: low


### PR DESCRIPTION
## What this does

Hardens the GitHub Actions supply chain for this repo:

1. **Pin all third-party Actions to full-length commit SHAs.**
   Every `uses:` in `MavenCI.yml` and `build-csharp.yml` now uses a 40-character SHA plus a comment naming the tag it resolves. Tag-based pins can be moved; SHA pins cannot. This defends against a compromised or retagged upstream Action.

2. **Add Dependabot for three ecosystems.**
   `.github/dependabot.yml` covers `github-actions` at `/`, `maven` at `/`, and `nuget` at `/multilang-schema-registry/csharp/AWSGsrSerDe`. Dependabot will now open weekly bump PRs so pinned SHAs do not go stale.

3. **Add zizmor CI.**
   `.github/workflows/zizmor.yml` runs zizmor on every push and pull request that touches `.github/workflows/**`. It reports findings to the Code Scanning tab. This catches new workflow issues before they land.

4. **Least-privilege plus no-persist-credentials.**
   Both existing workflows now declare top-level `permissions: contents: read` and every `actions/checkout` sets `persist-credentials: false`. The zizmor workflow uses `permissions: {}` at the top and grants `security-events: write` only on the one job that needs it.

## Why

CI is often the softest target in a repo. Unpinned Actions can be swapped upstream, over-scoped `GITHUB_TOKEN` can be reused across steps, and un-audited workflow YAML tends to drift. This PR closes those three gaps.

## What is not in this PR

- No changes to build, test, or release logic.
- No changes to code outside `.github/`.
- The pinned Action major versions are unchanged in this PR. The follow-up bumps (for example `actions/checkout@v2` and `actions/setup-java@v1`) will come as separate Dependabot PRs.

## How to verify

- `gh api repos/<owner>/<action>/git/ref/tags/<tag>` on each pinned SHA confirms the SHA matches the tag its comment claims.
- Running `zizmor .github/workflows/` locally on this branch prints no findings.
- The workflow itself will run on this PR and post any findings to the Checks tab.

## Note on zizmor's `known-vulnerable-actions` check

zizmor has one online audit, `known-vulnerable-actions`, that calls the GitHub API and needs a token. A local run without a token skips that audit. The CI run on this PR runs with `GH_TOKEN` and does exercise it, so the Checks tab on this PR is the real gate for that audit.

## Compatibility

Backwards-compatible. No public API, published artifact, or user-facing behavior changes.
