### PR TITLE
Bump Kafka to 3.9.2 to remediate CVE-2026-35554

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <aws.sdk.v2.version>2.32.25</aws.sdk.v2.version>
         <aws.sdk.v1.version>1.12.782</aws.sdk.v1.version>
         <kafka.scala.version>2.12</kafka.scala.version>
-        <kafka.version>3.6.1</kafka.version>
+        <kafka.version>3.9.2</kafka.version>
         <avro.version>1.11.4</avro.version>
         <mbknor.jsonschema.converter.version>1.0.39</mbknor.jsonschema.converter.version>
         <everit.json.schema.version>1.14.5</everit.json.schema.version>


### PR DESCRIPTION
*Issue #, if available:*

CVE-2026-35554 (CVSS 8.7 HIGH). No public GitHub issue; tracked internally as part of the GSR Client Library 2.0.0 security release.

https://nvd.nist.gov/vuln/detail/cve-2026-35554

*Description of changes:*

### Summary

CVE-2026-35554 (CVSS 8.7 HIGH) is a race condition in the Apache Kafka Java producer buffer pool. This change bumps the single `kafka.version` property in the root `pom.xml` from `3.6.1` to `3.9.2`, which is the fixed version on the Kafka 3.x line. Because every Kafka dependency in the reactor is pinned through that one property, the bump propagates to all five managed artifacts in one change:

- `kafka_2.12`
- `kafka-clients`
- `kafka-streams`
- `connect-api`
- `connect-json`

3.9.2 is the latest patch on the 3.9 line and is API-compatible with 3.6.1, so no source changes were required beyond the version property.

### Scope of change

- One line: `<kafka.version>3.6.1</kafka.version>` -> `<kafka.version>3.9.2</kafka.version>` in the root `pom.xml`.
- No production or test source code changes.
- No transitive-dependency conflicts surfaced during the reactor build.

### Validation on 3.9.2

- **Build**: `mvn clean verify` completes with BUILD SUCCESS across all 11 modules.
- **Unit tests**: approximately 1900 tests green across the full reactor, 0 failures.
- **Integration tests**: 73/73 pass end to end against a live Kafka broker running kafka-clients 3.9.2 and a real Glue Schema Registry, exercising the Avro, JSON, and Protobuf serializers and deserializers:
  - `GlueSchemaRegistryKafkaIntegrationTest`: 45 tests, 0 failures, 0 errors, 0 skipped.
  - `GlueSchemaRegistryKinesisIntegrationTest`: 28 tests, 0 failures, 0 errors, 0 skipped.

### Compatibility and risk

- 3.6.1 -> 3.9.2 is a minor/patch move within the Kafka 3.x major line, no breaking API changes for the client surfaces this library uses.
- Serialization wire format is unchanged; existing produced and consumed records remain compatible.
- Low risk: single dependency version property, fully covered by the existing unit and integration suites above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

### Test environment and coverage

Integration tests were run locally against a real Kafka broker (Confluent
cp-kafka 7.6.0 via Docker Compose) with kafka-clients 3.9.2, real AWS Glue
Schema Registry, and LocalStack 4.12 for Kinesis, DynamoDB, and CloudWatch.

- GlueSchemaRegistryKafkaIntegrationTest: 45 tests, 872 s, 0 failures/0 errors.
  Covers AVRO/JSON/PROTOBUF x specific/generic records x GSR NONE/ZLIB
  compression (single-threaded and multi-threaded producers), a Kafka Streams
  topology per format, native Kafka LZ4 compression, mixed-format topics, and
  a no-registry baseline.
- GlueSchemaRegistryKinesisIntegrationTest: 28 tests, 495 s, 0 failures/0 errors.
  Covers the same format/record/compression matrix through the Kinesis Producer
  Library and Kinesis Client Library.

The producer send paths exercised here (ZLIB and native LZ4 compression,
concurrent multi-threaded producers) directly cover the buffer-pool code path
affected by CVE-2026-35554.